### PR TITLE
優化 startswith & endwith 效能

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -673,9 +673,8 @@ namespace MiniExcelLibs.OpenXml
                     var v = XmlEncoder.DecodeString(rawValue);
                     if (_config.EnableConvertByteArray)
                     {
-                        //TODO:optimize startswith
                         //if str start with "data:image/png;base64," then convert to byte[] https://github.com/shps951023/MiniExcel/issues/318
-                        if (v != null && v.StartsWith("@@@fileid@@@,"))
+                        if (v != null && v.StartsWith("@@@fileid@@@,",StringComparison.Ordinal))
                         {
                             var path = v.Substring(13);
                             var stream = _archive.GetEntry(path).Open();

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -491,7 +491,7 @@ namespace MiniExcelLibs.OpenXml
             }
 
             var columname = ExcelOpenXmlUtils.ConvertXyToCell(cellIndex, rowIndex);
-            if (v != null && (v.StartsWith(" ") || v.EndsWith(" "))) /*Prefix and suffix blank space will lost after SaveAs #294*/
+            if (v != null && (v.StartsWith(" ",StringComparison.Ordinal) || v.EndsWith(" ",StringComparison.Ordinal))) /*Prefix and suffix blank space will lost after SaveAs #294*/
                 writer.Write($"<x:c r=\"{columname}\" {(t == null ? "" : $"t =\"{t}\"")} s=\"{s}\" xml:space=\"preserve\"><x:v>{v}</x:v></x:c>");
             else
                 //t check avoid format error ![image](https://user-images.githubusercontent.com/12729184/118770190-9eee3480-b8b3-11eb-9f5a-87a439f5e320.png)

--- a/src/MiniExcel/Utils/ExcelNumberFormat.cs
+++ b/src/MiniExcel/Utils/ExcelNumberFormat.cs
@@ -658,10 +658,10 @@ namespace MiniExcelLibs.Utils
         public static bool IsLiteral(string token)
         {
             return
-                token.StartsWith("_") ||
-                token.StartsWith("\\") ||
-                token.StartsWith("\"") ||
-                token.StartsWith("*") ||
+                token.StartsWith("_",StringComparison.Ordinal) ||
+                token.StartsWith("\\",StringComparison.Ordinal) ||
+                token.StartsWith("\"",StringComparison.Ordinal) ||
+                token.StartsWith("*",StringComparison.Ordinal) ||
                 token == "," ||
                 token == "!" ||
                 token == "&" ||

--- a/tests/MiniExcelTests/PerformanceEnhancementTest.cs
+++ b/tests/MiniExcelTests/PerformanceEnhancementTest.cs
@@ -1,0 +1,84 @@
+using CsvHelper;
+using MiniExcelLibs.Tests.Utils;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MiniExcelLibs.Tests
+{
+    public class PerformanceEnhancementTest
+    {
+        [Fact]
+        public void StartsWithPerformanceCompare()
+        {
+            string stringVal = "@@@fileid@@@,tteffadasdas ", findVal = "@@@fileid@@@,";
+            const int LOOP = 5000000;
+            int runTimes = 0;
+            long normalMilliseconds = 0;
+            long ordinalMilliseconds = 0;
+
+            Stopwatch watch = Stopwatch.StartNew();
+            for (int i = 0; i < LOOP; i++)
+            {
+                if (stringVal.StartsWith(findVal)) 
+                    runTimes++;
+            }
+            watch.Stop();
+            normalMilliseconds = watch.ElapsedMilliseconds;
+            Assert.Equal(LOOP, runTimes);
+
+            runTimes = 0;
+            watch = Stopwatch.StartNew();
+            for (int i = 0; i < LOOP; i++)
+            {
+                if (stringVal.StartsWith(findVal,StringComparison.Ordinal)) 
+                    runTimes++;
+            }
+            watch.Stop();
+            ordinalMilliseconds = watch.ElapsedMilliseconds;
+
+            Assert.Equal(LOOP, runTimes);
+            Assert.True(normalMilliseconds > ordinalMilliseconds);
+        }
+
+        [Fact]
+        public void EndWithPerformanceCompare()
+        {
+            string stringVal = "@@@fileid@@@,tteffadasdas ", findVal = " ";
+            const int LOOP = 5000000;
+            int runTimes = 0;
+            long normalMilliseconds = 0;
+            long ordinalMilliseconds = 0;
+
+            Stopwatch watch = Stopwatch.StartNew();
+            for (int i = 0; i < LOOP; i++)
+            {
+                if (stringVal.EndsWith(findVal)) 
+                    runTimes++;
+            }
+            watch.Stop();
+            normalMilliseconds = watch.ElapsedMilliseconds;
+            Assert.Equal(LOOP, runTimes);
+
+            runTimes = 0;
+            watch = Stopwatch.StartNew();
+            for (int i = 0; i < LOOP; i++)
+            {
+                if (stringVal.EndsWith(findVal,StringComparison.Ordinal)) 
+                    runTimes++;
+            }
+            watch.Stop();
+            ordinalMilliseconds = watch.ElapsedMilliseconds;
+
+            Assert.Equal(LOOP, runTimes);
+            Assert.True(normalMilliseconds > ordinalMilliseconds);
+        }
+    }
+}


### PR DESCRIPTION
我看目前使用 startswith & endwith 地方沒有用 culture 相關東西,建議使用  `StringComparison.Ordinal`  優化 startswith & endwith 效能



	string stringVal = "@@@fileid@@@,tteffadasdas ", findVal = " ";
	const int LOOP = 5000000;
	int runTimes = 0;
	long normalMilliseconds = 0;
	long ordinalMilliseconds = 0;

	Stopwatch watch = Stopwatch.StartNew();
	for (int i = 0; i < LOOP; i++)
	{
		if (stringVal.EndsWith(findVal)) 
			runTimes++;
	}
	watch.Stop();
	normalMilliseconds = watch.ElapsedMilliseconds;

	runTimes = 0;
	watch = Stopwatch.StartNew();
	for (int i = 0; i < LOOP; i++)
	{
		if (stringVal.EndsWith(findVal,StringComparison.Ordinal)) 
			runTimes++;
	}
	watch.Stop();
	ordinalMilliseconds = watch.ElapsedMilliseconds;

可以使用上面程式碼測試 `ordinalMilliseconds` 速度會快於 `normalMilliseconds` 好幾倍

