### PR TITLE
perf: excel writer performance 

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefualtOpenXml.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.DefualtOpenXml.cs
@@ -193,7 +193,7 @@ namespace MiniExcelLibs.OpenXml
 
         private void CreateZipEntry(string path,string contentType,string content)
         {
-            ZipArchiveEntry entry = _archive.CreateEntry(path);
+            ZipArchiveEntry entry = _archive.CreateEntry(path, CompressionLevel.Fastest);
             using (var zipStream = entry.Open())
             using (MiniExcelStreamWriter writer = new MiniExcelStreamWriter(zipStream, _utf8WithBom,_configuration.BufferSize))
                 writer.Write(content);
@@ -203,7 +203,7 @@ namespace MiniExcelLibs.OpenXml
 
         private void CreateZipEntry(string path, byte[] content)
         {
-            ZipArchiveEntry entry = _archive.CreateEntry(path);
+            ZipArchiveEntry entry = _archive.CreateEntry(path, CompressionLevel.Fastest);
             using (var zipStream = entry.Open())
                 zipStream.Write(content,0, content.Length);
         }

--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetWriter.cs
@@ -112,7 +112,7 @@ namespace MiniExcelLibs.OpenXml
 
         private void CreateSheetXml(object value, string sheetPath)
         {
-            ZipArchiveEntry entry = _archive.CreateEntry(sheetPath);
+            ZipArchiveEntry entry = _archive.CreateEntry(sheetPath, CompressionLevel.Fastest);
             using (var zipStream = entry.Open())
             using (MiniExcelStreamWriter writer = new MiniExcelStreamWriter(zipStream, _utf8WithBom,_configuration.BufferSize))
             {
@@ -749,7 +749,7 @@ namespace MiniExcelLibs.OpenXml
                 foreach (var p in _zipDictionary)
                     sb.Append($"<Override ContentType=\"{p.Value.ContentType}\" PartName=\"/{p.Key}\" />");
                 sb.Append("</Types>");
-                ZipArchiveEntry entry = _archive.CreateEntry("[Content_Types].xml");
+                ZipArchiveEntry entry = _archive.CreateEntry("[Content_Types].xml", CompressionLevel.Fastest);
                 using (var zipStream = entry.Open())
                 using (MiniExcelStreamWriter writer = new MiniExcelStreamWriter(zipStream, _utf8WithBom, _configuration.BufferSize))
                     writer.Write(sb.ToString());


### PR DESCRIPTION
通过配置Zip压缩级别 CompressionLevel.Fastest，极大的提升导出性能，而纯文本的压缩率并没有显著，甚至压缩率可能只提高1%，但带来的性能提升是非常显著的。
本地使用官方导出100万条Helloworld的基准测试，导出时间减少了30% （对比见图）
而我在其他的应用场景最高导出时间甚至可以比默认值减少50%。

本来想添加配置代码，但根据测试结果，导出文件尺寸只有增加了一点点，个人觉得没有必要增加配置项。

![88c1eee5afb8d23fba404e0067782d7](https://user-images.githubusercontent.com/8878704/178940172-3e66a42b-8ed6-42ff-9aaa-d8903f8fc9c7.png)
