### PR TITLE
Changing the location where the shared strings cache is stored

### DIFF
--- a/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
+++ b/src/MiniExcel/OpenXml/ExcelOpenXmlSheetReader.cs
@@ -449,7 +449,7 @@ namespace MiniExcelLibs.OpenXml
                 var idx = 0;
                 if (_config.EnableSharedStringCache && sharedStringsEntry.Length >= _config.SharedStringCacheSize)
                 {
-                    _sharedStrings = new SharedStringsDiskCache();
+                    _sharedStrings = new SharedStringsDiskCache(_config.SharedStringCachePath);
                     foreach (var sharedString in XmlReaderHelper.GetSharedStrings(stream, _ns))
                         _sharedStrings[idx++] = sharedString;
                 }

--- a/src/MiniExcel/OpenXml/OpenXmlConfiguration.cs
+++ b/src/MiniExcel/OpenXml/OpenXmlConfiguration.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using MiniExcelLibs.Attributes;
 
 namespace MiniExcelLibs.OpenXml
@@ -18,6 +19,13 @@ namespace MiniExcelLibs.OpenXml
         public bool IgnoreEmptyRows { get; set; } = false;
         public bool EnableSharedStringCache { get; set; } = true;
         public long SharedStringCacheSize { get; set; } = 5 * 1024 * 1024;
+
+        /// <summary>
+        /// The directory where the shared strings cache files are stored.
+        /// It defaults to the system's temporary folder.
+        /// </summary>
+        public string SharedStringCachePath { get; set; } = Path.GetTempPath();
+
         public OpenXmlStyleOptions StyleOptions { get; set; } = new OpenXmlStyleOptions();
         public DynamicExcelSheet[] DynamicSheets { get; set; }
         public bool EnableWriteFilePath{ get; set; } = true;

--- a/src/MiniExcel/OpenXml/SharedStringsDiskCache.cs
+++ b/src/MiniExcel/OpenXml/SharedStringsDiskCache.cs
@@ -23,12 +23,15 @@ namespace MiniExcelLibs.OpenXml
             return key <= _maxIndx;
         }
 
-        public SharedStringsDiskCache()
+        public SharedStringsDiskCache(string sharedStringsCacheDir)
         {
-            var path = $"{Guid.NewGuid().ToString()}_miniexcelcache";
-            _positionFs = new FileStream($"{path}_position", FileMode.OpenOrCreate);
-            _lengthFs = new FileStream($"{path}_length", FileMode.OpenOrCreate);
-            _valueFs = new FileStream($"{path}_data", FileMode.OpenOrCreate);
+            if (string.IsNullOrWhiteSpace(sharedStringsCacheDir) || !Directory.Exists(sharedStringsCacheDir))
+                throw new DirectoryNotFoundException($"\"{sharedStringsCacheDir}\" is not a valid directory for the shared strings cache.");
+
+            var prefix = $"{Path.GetRandomFileName()}_miniexcel";
+            _positionFs = new FileStream(Path.Combine(sharedStringsCacheDir, $"{prefix}_position"), FileMode.OpenOrCreate);
+            _lengthFs = new FileStream(Path.Combine(sharedStringsCacheDir, $"{prefix}_length"), FileMode.OpenOrCreate);
+            _valueFs = new FileStream(Path.Combine(sharedStringsCacheDir, $"{prefix}_data"), FileMode.OpenOrCreate);
         }
 
         // index must start with 0-N
@@ -140,13 +143,13 @@ namespace MiniExcelLibs.OpenXml
 
         public IEnumerator<KeyValuePair<int, string>> GetEnumerator()
         {
-            for (int i = 0; i < _maxIndx; i++)
+            for (int i = 0; i <= _maxIndx; i++)
                 yield return new KeyValuePair<int, string>(i, this[i]);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            for (int i = 0; i < _maxIndx; i++)
+            for (int i = 0; i <= _maxIndx; i++)
                 yield return this[i];
         }
 

--- a/tests/MiniExcelTests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcelTests/MiniExcelIssueTests.cs
@@ -413,7 +413,7 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
     public void TestIssue117()
     {
         {
-            var cache = new SharedStringsDiskCache();
+            var cache = new SharedStringsDiskCache(Path.GetTempPath());
             for (int i = 0; i < 100; i++)
             {
                 cache[i] = i.ToString();
@@ -425,7 +425,7 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
             Assert.Equal(100, cache.Count);
         }
         {
-            var cache = new SharedStringsDiskCache();
+            var cache = new SharedStringsDiskCache(Path.GetTempPath());
             Assert.Empty(cache);
         }
     }


### PR DESCRIPTION
- Mirrors PR #897 on the maintenance branch
- Changes the shared string cache base path to use `Path.GetTempPath` by default instead of creating temporary files in the program's working directory
- Adds an option to `OpenXmlConfiguration` for manually overriding aferomentioned temporary path