### PR TITLE
docs: add horizontal fill workaround

### DIFF
--- a/README-V2.md
+++ b/README-V2.md
@@ -1685,6 +1685,35 @@ class Dto
 }
 ```
 
+#### Q. How do I fill data horizontally (left-to-right) with templates?
+
+A. MiniExcel template collections currently expand vertically (top-to-bottom). Horizontal (left-to-right) fill isn't supported yet (see https://github.com/mini-software/MiniExcel/issues/619).
+
+If you just need the final layout, transpose your data into a matrix and export it with `printHeader: false`:
+
+```csharp
+var employees = new[]
+{
+    new { Name = "Name1", Department = "Department1", City = "City1", Country = "Country1" },
+    new { Name = "Name2", Department = "Department2", City = "City2", Country = "Country2" },
+    new { Name = "Name3", Department = "Department3", City = "City3", Country = "Country3" },
+};
+
+var table = new DataTable();
+table.Columns.Add("A");
+for (var i = 0; i < employees.Length; i++)
+    table.Columns.Add($"B{i + 1}");
+
+table.Rows.Add(new object[] { "Name" }.Concat(employees.Select(e => (object)e.Name)).ToArray());
+table.Rows.Add(new object[] { "Department" }.Concat(employees.Select(e => (object)e.Department)).ToArray());
+table.Rows.Add(new object[] { "City" }.Concat(employees.Select(e => (object)e.City)).ToArray());
+table.Rows.Add(new object[] { "Country" }.Concat(employees.Select(e => (object)e.Country)).ToArray());
+
+MiniExcel.SaveAs(path, table, printHeader: false);
+```
+
+If you need template styling, one workaround is to use scalar placeholders (e.g. `{{Name_1}}`, `{{Name_2}}` ...) and fill a dictionary (requires a fixed maximum number of columns).
+
 #### Q. How do I query multiple sheets of an Excel file?
 
 A. You can retrieve the sheet names with the `GetSheetNames` method and then Query them using the `sheetName` parameter:

--- a/README.md
+++ b/README.md
@@ -745,37 +745,6 @@ var value = new Dictionary<string, object>()
 MiniExcel.SaveAsByTemplate(path, templatePath, value);
 ```
 
-##### Workaround: Horizontal fill (transpose)
-
-MiniExcel template collection rendering expands vertically (top-to-bottom). Horizontal (left-to-right) fill isn't supported yet (see https://github.com/mini-software/MiniExcel/issues/619).
-
-If you just need the final layout, transpose your data into a matrix and export it with `printHeader: false`:
-
-```csharp
-var employees = new[]
-{
-    new { Name = "Name1", Department = "Department1", City = "City1", Country = "Country1" },
-    new { Name = "Name2", Department = "Department2", City = "City2", Country = "Country2" },
-    new { Name = "Name3", Department = "Department3", City = "City3", Country = "Country3" },
-};
-
-var table = new DataTable();
-table.Columns.Add("A");
-for (var i = 0; i < employees.Length; i++)
-    table.Columns.Add($"B{i + 1}");
-
-table.Rows.Add(new object[] { "Name" }.Concat(employees.Select(e => (object)e.Name)).ToArray());
-table.Rows.Add(new object[] { "Department" }.Concat(employees.Select(e => (object)e.Department)).ToArray());
-table.Rows.Add(new object[] { "City" }.Concat(employees.Select(e => (object)e.City)).ToArray());
-table.Rows.Add(new object[] { "Country" }.Concat(employees.Select(e => (object)e.Country)).ToArray());
-
-MiniExcel.SaveAs(path, table, printHeader: false);
-```
-
-If you must use a template for styling, one option is to use scalar placeholders (e.g. `{{Name_1}}`, `{{Name_2}}` ...) and fill a dictionary (requires a fixed maximum number of columns).
-
-
-
 #### 3. Complex Data Fill
 
 > Note: Support multi-sheets and using same varible
@@ -1849,6 +1818,35 @@ foreach (var sheetInfo in sheets)
     Console.WriteLine($"sheet state : {sheetInfo.State} "); // sheet visibility state - visible / hidden
 }
 ```
+
+#### Q. How to fill data horizontally (left-to-right) with templates?
+
+A. MiniExcel template collection rendering expands vertically (top-to-bottom). Horizontal (left-to-right) fill isn't supported yet (see https://github.com/mini-software/MiniExcel/issues/619).
+
+If you just need the final layout, transpose your data into a matrix and export it with `printHeader: false`:
+
+```csharp
+var employees = new[]
+{
+    new { Name = "Name1", Department = "Department1", City = "City1", Country = "Country1" },
+    new { Name = "Name2", Department = "Department2", City = "City2", Country = "Country2" },
+    new { Name = "Name3", Department = "Department3", City = "City3", Country = "Country3" },
+};
+
+var table = new DataTable();
+table.Columns.Add("A");
+for (var i = 0; i < employees.Length; i++)
+    table.Columns.Add($"B{i + 1}");
+
+table.Rows.Add(new object[] { "Name" }.Concat(employees.Select(e => (object)e.Name)).ToArray());
+table.Rows.Add(new object[] { "Department" }.Concat(employees.Select(e => (object)e.Department)).ToArray());
+table.Rows.Add(new object[] { "City" }.Concat(employees.Select(e => (object)e.City)).ToArray());
+table.Rows.Add(new object[] { "Country" }.Concat(employees.Select(e => (object)e.Country)).ToArray());
+
+MiniExcel.SaveAs(path, table, printHeader: false);
+```
+
+If you must use a template for styling, one option is to use scalar placeholders (e.g. `{{Name_1}}`, `{{Name_2}}` ...) and fill a dictionary (requires a fixed maximum number of columns).
 
 
 #### Q. Whether to use Count will load all data into the memory?

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -737,37 +737,6 @@ var value = new Dictionary<string, object>()
 MiniExcel.SaveAsByTemplate(path, templatePath, value);
 ```
 
-##### 变通方法：横向填充（转置）
-
-MiniExcel 模板的集合渲染目前只支持纵向（从上到下）扩展，不支持横向（从左到右）扩展（见 https://github.com/mini-software/MiniExcel/issues/619）。
-
-如果只需要最终布局，可以先把数据转置成一个矩阵，再用 `printHeader: false` 导出：
-
-```csharp
-var employees = new[]
-{
-    new { Name = "Name1", Department = "Department1", City = "City1", Country = "Country1" },
-    new { Name = "Name2", Department = "Department2", City = "City2", Country = "Country2" },
-    new { Name = "Name3", Department = "Department3", City = "City3", Country = "Country3" },
-};
-
-var table = new DataTable();
-table.Columns.Add("A");
-for (var i = 0; i < employees.Length; i++)
-    table.Columns.Add($"B{i + 1}");
-
-table.Rows.Add(new object[] { "Name" }.Concat(employees.Select(e => (object)e.Name)).ToArray());
-table.Rows.Add(new object[] { "Department" }.Concat(employees.Select(e => (object)e.Department)).ToArray());
-table.Rows.Add(new object[] { "City" }.Concat(employees.Select(e => (object)e.City)).ToArray());
-table.Rows.Add(new object[] { "Country" }.Concat(employees.Select(e => (object)e.Country)).ToArray());
-
-MiniExcel.SaveAs(path, table, printHeader: false);
-```
-
-如果必须使用模板以保留样式，一种方式是在模板里使用标量占位符（例如 `{{Name_1}}`、`{{Name_2}}` …）并用 Dictionary 填充；这种方式需要预先确定最大列数。
-
-
-
 #### 3. 复杂数据填充
 
 > Note: 支持多 sheet 填充,并共用同一组参数
@@ -1728,6 +1697,35 @@ foreach (var sheet in sheets)
 ```
 
 ![image](https://user-images.githubusercontent.com/12729184/116199841-2a1f5300-a76a-11eb-90a3-6710561cf6db.png)
+
+#### Q. 模板能否横向（从左到右）填充集合数据？
+
+A. MiniExcel 模板的集合渲染目前只支持纵向（从上到下）扩展，不支持横向（从左到右）扩展（见 https://github.com/mini-software/MiniExcel/issues/619）。
+
+如果只需要最终布局，可以先把数据转置成一个矩阵，再用 `printHeader: false` 导出：
+
+```csharp
+var employees = new[]
+{
+    new { Name = "Name1", Department = "Department1", City = "City1", Country = "Country1" },
+    new { Name = "Name2", Department = "Department2", City = "City2", Country = "Country2" },
+    new { Name = "Name3", Department = "Department3", City = "City3", Country = "Country3" },
+};
+
+var table = new DataTable();
+table.Columns.Add("A");
+for (var i = 0; i < employees.Length; i++)
+    table.Columns.Add($"B{i + 1}");
+
+table.Rows.Add(new object[] { "Name" }.Concat(employees.Select(e => (object)e.Name)).ToArray());
+table.Rows.Add(new object[] { "Department" }.Concat(employees.Select(e => (object)e.Department)).ToArray());
+table.Rows.Add(new object[] { "City" }.Concat(employees.Select(e => (object)e.City)).ToArray());
+table.Rows.Add(new object[] { "Country" }.Concat(employees.Select(e => (object)e.Country)).ToArray());
+
+MiniExcel.SaveAs(path, table, printHeader: false);
+```
+
+如果必须使用模板以保留样式，一种方式是在模板里使用标量占位符（例如 `{{Name_1}}`、`{{Name_2}}` …）并用 Dictionary 填充；这种方式需要预先确定最大列数。
 
 
 


### PR DESCRIPTION
Issue #619 asks about filling data horizontally (left-to-right) with MiniExcel templates.

MiniExcel template collection rendering currently expands vertically (top-to-bottom), so this PR adds a small doc section (EN + zh-CN) that:
- clarifies the current limitation
- shows a copy/paste workaround by transposing data into a matrix and exporting with `MiniExcel.SaveAs(..., printHeader: false)`
- mentions an alternative using scalar placeholders for a fixed maximum column count

Refs #619.
