### PR TITLE
fix: fix template export generating corrupted Excel files

### DIFF
--- a/src/MiniExcel.Core/OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.Core/OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -1177,7 +1177,7 @@ internal partial class OpenXmlTemplate
             if (isNode != null)
             {
                 var tNode = isNode.SelectSingleNode("x:t", Ns);
-                var text = tNode?.InnerText;
+                var text = tNode?.InnerText ?? string.Empty;
                 c.RemoveChild(isNode);
                 var v = string.IsNullOrEmpty(prefix)
                     ? c.OwnerDocument.CreateElement("v", Schemas.SpreadsheetmlXmlns)

--- a/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
+++ b/tests/MiniExcel.Core.Tests/MiniExcelIssueTests.cs
@@ -1042,8 +1042,9 @@ public class MiniExcelIssueTests(ITestOutputHelper output)
          _excelTemplater.ApplyTemplate(path.ToString(), templatePath, value);
 
         var sheetXml = SheetHelper.GetZipFileContent(path.ToString(), "xl/worksheets/sheet1.xml");
-        Assert.Contains("<v>Hello &amp; World &lt; , &gt; , \" , '</v>", sheetXml);
-        Assert.Contains("<v>Hello &amp; Value &lt; , &gt; , \" , '</v>", sheetXml);
+        // Template now uses inlineStr format (<is><t>...</t></is>) instead of SharedStrings (<v>...</v>)
+        Assert.Contains("<t>Hello &amp; World &lt; , &gt; , \" , '</t>", sheetXml);
+        Assert.Contains("<t>Hello &amp; Value &lt; , &gt; , \" , '</t>", sheetXml);
     }
 
     /// <summary>


### PR DESCRIPTION
## Description
This PR addresses a bug where Excel files generated from templates could become corrupted or throw an "XML error" upon opening.

## Problem

When using `MiniExcel.SaveAsByTemplate()` with Excel templates containing SharedStrings, the generated files would fail to open in Excel with the error "We found a problem with some content in 'xxx.xlsx'".
<img width="1044" height="191" alt="image" src="https://github.com/user-attachments/assets/2cab7afd-85d8-4ad0-af78-61a81800f747" />

template:
[GachaLog.xlsx](https://github.com/user-attachments/files/24829082/GachaLog.xlsx)

demo error file:
[1.xslx](https://github.com/user-attachments/files/24642338/Starward_Export_hkrpg_110751147_20260115201153.xlsx)

logic code:
```
    private async Task ExportAsExcelAsync(long uid, string output)
    {
        using var dapper = DatabaseService.CreateConnection();
        var list = GetGachaLogItemEx(uid);
        var template = Path.Combine(AppContext.BaseDirectory, @"Assets\Template\GachaLog.xlsx");
        if (File.Exists(template))
        {
            await MiniExcel.SaveAsByTemplateAsync(output, template, new { list });
        }
    }
```
### Root Causes

1. **Invalid cell type for SharedStrings**: The code was setting `t="str"` with `<v>` element, but OpenXML requires `t="inlineStr"` with `<is><t>...</t></is>` structure for inline strings.

2. **Incorrect XML element order**: Elements were written in wrong order. Per ECMA-376 specification, the correct order after `</sheetData>` must be: `autoFilter` → `mergeCells` → `phoneticPr` → `conditionalFormatting`.

3. **Duplicate namespace declarations**: `phoneticPr`, `conditionalFormatting`, and `autoFilter` elements contained redundant `xmlns="..."` declarations when written to the output.

4. **Number cells with wrong type attribute**: Numeric cells were incorrectly getting `t="inlineStr"` attribute, which should be omitted for numbers.


### Related Issue
[issue1](https://github.com/Scighost/Starward/issues/1728)
[issue2](https://github.com/Scighost/Starward/issues/744)

## Changes

- **`ReplaceSharedStringsToStr`**: Convert SharedString references to proper `inlineStr` format with `<is><t>` structure
- **New `SetCellType` method**: Centralized cell type handling - uses `inlineStr` for strings, removes `t` attribute for numbers
- **`WriteSheetXmlAsync`**: Fixed element order per ECMA-376 spec, extract and rewrite `autoFilter` in correct position
- **`CleanXml`**: Added cleanup for `xmlns="..."` declarations
- **`GenerateCellValuesAsync`**: Clean up empty `<v></v>` tags, support `<is><t>` structure in value lookup


## Testing

- Tested with template containing 3650 rows of data
- Generated file opens successfully in Microsoft Excel without repair prompts
- Verified XML structure compliance with ECMA-376 specification

## Breaking Changes

None. These are bug fixes that produce valid OpenXML output.