### PR TITLE
Cell alignment support

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,16 +1,12 @@
 <Project>
-
-    <ItemGroup>
-        <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.6.13" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-        <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Zomp.SyncMethodGenerator" Version="1.6.13" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
@@ -405,13 +405,22 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
 
-        var cell1HorizontalAlignment = _styleOptions.HorizontalAlignment;
-        var cell1HorizontalAlignmentStr = cell1HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell1HorizontalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell1HorizontalAlignmentStr).ConfigureAwait(false);
+        var style1HorizontalAlignment = _styleOptions.HorizontalAlignment switch
+        {
+            HorizontalCellAlignment.Center => "center",
+            HorizontalCellAlignment.Right => "right",
+            _ => "general"
+        };
 
-        var cell1VerticalAlignment = _styleOptions.VerticalAlignment;
-        var cell1VerticalAlignmentStr = cell1VerticalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell1VerticalAlignmentStr).ConfigureAwait(false);
+        var style1VerticalAlignment = _styleOptions.VerticalAlignment switch
+        {
+            VerticalCellAlignment.Top => "top",
+            VerticalCellAlignment.Center => "center",
+            _ => "bottom"
+        };
+        
+        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, style1HorizontalAlignment).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, style1VerticalAlignment).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
 
         var wrapContent = _styleOptions.WrapCellContents ? "1" : "0";
@@ -448,13 +457,22 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
 
-        var cell2HorizontalAlignment = _styleOptions.HorizontalAlignment;
-        var cell2HorizontalAlignmentStr = cell2HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell2HorizontalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell2HorizontalAlignmentStr).ConfigureAwait(false);
+        var style2HorizontalAlignment = _styleOptions.HorizontalAlignment switch
+        {
+            HorizontalCellAlignment.Center => "center",
+            HorizontalCellAlignment.Right => "right",
+            _ => "general"
+        };
 
-        var cell2VerticalAlignment = _styleOptions.VerticalAlignment;
-        var cell2VerticalAlignmentStr = cell2VerticalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell2VerticalAlignmentStr).ConfigureAwait(false);
+        var style2VerticalAlignment = _styleOptions.VerticalAlignment switch
+        {
+            VerticalCellAlignment.Top => "top",
+            VerticalCellAlignment.Center => "center",
+            _ => "bottom"
+        };
+
+        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, style2HorizontalAlignment).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, style2VerticalAlignment).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);
@@ -512,13 +530,22 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
             await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
             await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
 
-            var cell3HorizontalAlignment = _styleOptions.HorizontalAlignment;
-            var cell3HorizontalAlignmentStr = cell3HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell3HorizontalAlignment.ToString().ToLowerInvariant();
-            await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell3HorizontalAlignmentStr).ConfigureAwait(false);
+            var style3HorizontalAlignment = _styleOptions.HorizontalAlignment switch
+            {
+                HorizontalCellAlignment.Center => "center",
+                HorizontalCellAlignment.Right => "right",
+                _ => "general"
+            };
 
-            var cell3VerticalAlignment = _styleOptions.VerticalAlignment;
-            var cell3VerticalAlignmentStr = cell3VerticalAlignment.ToString().ToLowerInvariant();
-            await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell3VerticalAlignmentStr).ConfigureAwait(false);
+            var style3VerticalAlignment = _styleOptions.VerticalAlignment switch
+            {
+                VerticalCellAlignment.Top => "top",
+                VerticalCellAlignment.Center => "center",
+                _ => "bottom"
+            };
+            
+            await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, style3HorizontalAlignment).ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "vertical", null, style3VerticalAlignment).ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, "0").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
@@ -19,12 +19,12 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
     private static readonly Color DefaultBackgroundColor = Color.FromArgb(0x284472C4);
     private const HorizontalCellAlignment DefaultHorizontalAlignment = HorizontalCellAlignment.Left;
     private const VerticalCellAlignment DefaultVerticalAlignment = VerticalCellAlignment.Bottom;
-    
+
     private readonly SheetStyleBuildContext _context = context;
     private readonly OpenXmlStyleOptions _styleOptions = styleOptions;
 
     private XmlReader OldReader => _context.OldXmlReader!;
-    private XmlWriter NewWriter => _context.NewXmlWriter!; 
+    private XmlWriter NewWriter => _context.NewXmlWriter!;
 
     protected override SheetStyleElementInfos GetGenerateElementInfos()
     {
@@ -148,7 +148,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         var bgColor = _styleOptions.HeaderStyle?.BackgroundColor ?? DefaultBackgroundColor;
         var hexBgColor = $"{bgColor.A:X2}{bgColor.R:X2}{bgColor.G:X2}{bgColor.B:X2}";
         await NewWriter.WriteAttributeStringAsync(null, "rgb", null, hexBgColor).ConfigureAwait(false);
-        
+
         await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
         await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
         await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
@@ -360,20 +360,20 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         await NewWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
-        
-        var horizontalAlignment = _styleOptions.HeaderStyle?.HorizontalAlignment ?? DefaultHorizontalAlignment;
-        var horizontalAlignmentStr = horizontalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, horizontalAlignmentStr).ConfigureAwait(false);
-        
-        var verticalAlignment = _styleOptions.HeaderStyle?.VerticalAlignment ?? DefaultVerticalAlignment;
-        var verticalAlignmentStr = verticalAlignment.ToString().ToLowerInvariant();
-        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, verticalAlignmentStr).ConfigureAwait(false);
-        
+
+        var headerHorizontalAlignment = _styleOptions.HeaderStyle?.HorizontalAlignment ?? DefaultHorizontalAlignment;
+        var headerHorizontalAlignmentStr = headerHorizontalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, headerHorizontalAlignmentStr).ConfigureAwait(false);
+
+        var headerVerticalAlignment = _styleOptions.HeaderStyle?.VerticalAlignment ?? DefaultVerticalAlignment;
+        var headerVerticalAlignmentStr = headerVerticalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, headerVerticalAlignmentStr).ConfigureAwait(false);
+
         await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
 
         var wrapHeader = (_styleOptions.HeaderStyle?.WrapText ?? false) ? "1" : "0";
         await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, wrapHeader).ConfigureAwait(false);
-        
+
         await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0").ConfigureAwait(false);
@@ -404,13 +404,19 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         await NewWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, "general").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom").ConfigureAwait(false);
+
+        var cell1HorizontalAlignment = _styleOptions.HorizontalAlignment;
+        var cell1HorizontalAlignmentStr = cell1HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell1HorizontalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell1HorizontalAlignmentStr).ConfigureAwait(false);
+
+        var cell1VerticalAlignment = _styleOptions.VerticalAlignment;
+        var cell1VerticalAlignmentStr = cell1VerticalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell1VerticalAlignmentStr).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
-        
+
         var wrapContent = _styleOptions.WrapCellContents ? "1" : "0";
         await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, wrapContent).ConfigureAwait(false);
-        
+
         await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "relativeIndent", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "justifyLastLine", null, "0").ConfigureAwait(false);
@@ -441,8 +447,14 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         await NewWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, "general").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom").ConfigureAwait(false);
+
+        var cell2HorizontalAlignment = _styleOptions.HorizontalAlignment;
+        var cell2HorizontalAlignmentStr = cell2HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell2HorizontalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell2HorizontalAlignmentStr).ConfigureAwait(false);
+
+        var cell2VerticalAlignment = _styleOptions.VerticalAlignment;
+        var cell2VerticalAlignmentStr = cell2VerticalAlignment.ToString().ToLowerInvariant();
+        await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell2VerticalAlignmentStr).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);
@@ -499,8 +511,14 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
             await NewWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "applyProtection", null, "1").ConfigureAwait(false);
             await NewWriter.WriteStartElementAsync(OldReader.Prefix, "alignment", OldReader.NamespaceURI).ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, "general").ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "vertical", null, "bottom").ConfigureAwait(false);
+
+            var cell3HorizontalAlignment = _styleOptions.HorizontalAlignment;
+            var cell3HorizontalAlignmentStr = cell3HorizontalAlignment == HorizontalCellAlignment.Left ? "general" : cell3HorizontalAlignment.ToString().ToLowerInvariant();
+            await NewWriter.WriteAttributeStringAsync(null, "horizontal", null, cell3HorizontalAlignmentStr).ConfigureAwait(false);
+
+            var cell3VerticalAlignment = _styleOptions.VerticalAlignment;
+            var cell3VerticalAlignmentStr = cell3VerticalAlignment.ToString().ToLowerInvariant();
+            await NewWriter.WriteAttributeStringAsync(null, "vertical", null, cell3VerticalAlignmentStr).ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "textRotation", null, "0").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "wrapText", null, "0").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "indent", null, "0").ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlStyleOptions.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlStyleOptions.cs
@@ -1,7 +1,11 @@
 namespace MiniExcelLib.OpenXml.Styles;
 
+using MiniExcelLib.Core.Enums;
+
 public class OpenXmlStyleOptions
 {
     public bool WrapCellContents { get; set; }
-    public OpenXmlHeaderStyle? HeaderStyle { get; set; } 
+    public OpenXmlHeaderStyle? HeaderStyle { get; set; }
+    public HorizontalCellAlignment HorizontalAlignment { get; set; } = HorizontalCellAlignment.Left;
+    public VerticalCellAlignment VerticalAlignment { get; set; } = VerticalCellAlignment.Bottom;
 }


### PR DESCRIPTION
## What's Changed

### 1. Security Updates
- Updated vulnerable NuGet packages to address security vulnerabilities

### 2. New Feature: Cell Alignment Support
- Added `HorizontalAlignment` and `VerticalAlignment` properties to `OpenXmlStyleOptions` class
- Modified `DefaultSheetStyleBuilder` to use these properties when generating cell styles
- Added support for setting cell alignment through configuration

## How to Use

```csharp
// Example: Set center alignment for all cells
var styleOptions = new OpenXmlStyleOptions
{
    HorizontalAlignment = HorizontalCellAlignment.Center,
    VerticalAlignment = VerticalCellAlignment.Center,
    WrapCellContents = true
};

var configuration = new OpenXmlConfiguration
{
    StyleOptions = styleOptions
};

using var stream = new MemoryStream();
await stream.SaveAsAsync(data, configuration: configuration);
```

## Available Alignment Options

### Horizontal Alignment:
- `Left` (default)
- `Center`
- `Right`

### Vertical Alignment:
- `Top`
- `Center`
- `Bottom` (default)