### PR TITLE
Added polyfills and simplified preprocessor directives

### DIFF
--- a/src/MiniExcel.Core/Helpers/ExpandoHelper.cs
+++ b/src/MiniExcel.Core/Helpers/ExpandoHelper.cs
@@ -10,12 +10,7 @@ public static class ExpandoHelper
         for (int i = startCellIndex; i <= maxColumnIndex; i++)
         {
             var key = CellReferenceConverter.GetAlphabeticalIndex(i);
-#if NETCOREAPP2_0_OR_GREATER
             cell.TryAdd(key, null);
-#else
-            if (!cell.ContainsKey(key))
-                cell.Add(key, null);
-#endif
         }
 
         return cell;
@@ -26,12 +21,7 @@ public static class ExpandoHelper
         IDictionary<string, object?> cell = new ExpandoObject();
         foreach (var hr in headers)
         {
-#if NETCOREAPP2_0_OR_GREATER
             cell.TryAdd(hr.Value, null);
-#else
-            if (!cell.ContainsKey(hr.Value))
-                cell.Add(hr.Value, null);
-#endif
         }
 
         return cell;

--- a/src/MiniExcel.Core/Helpers/MiniExcelStreamWriter.cs
+++ b/src/MiniExcel.Core/Helpers/MiniExcelStreamWriter.cs
@@ -12,7 +12,7 @@ public sealed partial class MiniExcelStreamWriter(Stream stream, Encoding encodi
     {
         if (!string.IsNullOrEmpty(content))
         {
-#if NET8_0_OR_GREATER
+#if NET
             await _streamWriter.WriteAsync(content.AsMemory(), cancellationToken)
 #else
             cancellationToken.ThrowIfCancellationRequested();
@@ -33,7 +33,7 @@ public sealed partial class MiniExcelStreamWriter(Stream stream, Encoding encodi
     public async Task<long> FlushAndGetPositionAsync(CancellationToken cancellationToken = default)
     {
         await _streamWriter.FlushAsync(
-#if NET8_0_OR_GREATER
+#if NET
             cancellationToken
 #endif
         ).ConfigureAwait(false);

--- a/src/MiniExcel.Core/Helpers/MiniExcelStreamWriter.cs
+++ b/src/MiniExcel.Core/Helpers/MiniExcelStreamWriter.cs
@@ -13,12 +13,11 @@ public sealed partial class MiniExcelStreamWriter(Stream stream, Encoding encodi
         if (!string.IsNullOrEmpty(content))
         {
 #if NET
-            await _streamWriter.WriteAsync(content.AsMemory(), cancellationToken)
+            await _streamWriter.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
 #else
             cancellationToken.ThrowIfCancellationRequested();
-            await _streamWriter.WriteAsync(content)
+            await _streamWriter.WriteAsync(content).ConfigureAwait(false);
 #endif
-                .ConfigureAwait(false);
         }
     }
 

--- a/src/MiniExcel.Core/Helpers/Polyfills.cs
+++ b/src/MiniExcel.Core/Helpers/Polyfills.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.IO.Compression;
+using System.Runtime.InteropServices;
 using System.Xml.Linq;
 
 namespace MiniExcelLib.Core.Helpers;
@@ -58,6 +59,47 @@ public static class Polyfills
                 yield return element;
             }
         }
+    }
+
+    extension(Stream? stream)
+    {
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public ValueTask DisposeAsync()
+        {
+            if (stream is IAsyncDisposable asyncDisposable)
+                return asyncDisposable.DisposeAsync();
+    
+            stream?.Dispose();
+            return default;
+        }
+    
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public StreamConfiguredAsyncDisposable ConfigureAwait(bool continueOnCapturedContext) 
+            => new(stream, continueOnCapturedContext);
+    }
+
+    /// <summary>
+    /// This is a copy of the runtime's <see cref="ConfiguredAsyncDisposable" />, which we cannot instantiate directly for our needs
+    /// due to the constructor that initializes the object to eventually dispose being internal. 
+    /// </summary>
+    [StructLayout(LayoutKind.Auto)]
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public readonly struct StreamConfiguredAsyncDisposable : IDisposable
+    {
+        private readonly Stream? _source;
+        private readonly bool _continueOnCapturedContext;
+    
+        internal StreamConfiguredAsyncDisposable(Stream? source, bool continueOnCapturedContext)
+        {
+            _source = source;
+            _continueOnCapturedContext = continueOnCapturedContext;
+        }
+    
+        public ConfiguredValueTaskAwaitable DisposeAsync() 
+            => _source.DisposeAsync().ConfigureAwait(_continueOnCapturedContext);
+
+        public void Dispose() 
+            => _source?.Dispose();
     }
 #endif
 

--- a/src/MiniExcel.Core/Helpers/Polyfills.cs
+++ b/src/MiniExcel.Core/Helpers/Polyfills.cs
@@ -16,6 +16,16 @@ public static class Polyfills
     }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
+    public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        if (dictionary.ContainsKey(key))
+            return false;
+ 
+        dictionary.Add(key, value);
+        return true;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Advanced)]
     public static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> kvp, out TKey key, out TValue value)
     {
         key = kvp.Key;

--- a/src/MiniExcel.Core/Helpers/Polyfills.cs
+++ b/src/MiniExcel.Core/Helpers/Polyfills.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.IO.Compression;
+using System.Xml.Linq;
 
 namespace MiniExcelLib.Core.Helpers;
 
@@ -9,20 +10,23 @@ namespace MiniExcelLib.Core.Helpers;
 public static class Polyfills
 {
 #if NETSTANDARD2_0
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public static TValue? GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue? defaultValue = default)
+    extension<TKey, TValue>(IDictionary<TKey, TValue> dictionary)
     {
-        return dictionary.TryGetValue(key, out var value) ? value : defaultValue;
-    }
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public TValue? GetValueOrDefault(TKey key, TValue? defaultValue = default)
+        {
+            return dictionary.TryGetValue(key, out var value) ? value : defaultValue;
+        }
 
-    [EditorBrowsable(EditorBrowsableState.Advanced)]
-    public static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
-    {
-        if (dictionary.ContainsKey(key))
-            return false;
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public bool TryAdd(TKey key, TValue value)
+        {
+            if (dictionary.ContainsKey(key))
+                return false;
  
-        dictionary.Add(key, value);
-        return true;
+            dictionary.Add(key, value);
+            return true;
+        }
     }
 
     [EditorBrowsable(EditorBrowsableState.Advanced)]
@@ -65,6 +69,22 @@ public static class Polyfills
         {
             var stream = entry.Open();
             return new ValueTask<Stream>(stream);
+        }
+    }
+
+    extension(XDocument doc)
+    {
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public static ValueTask<XDocument> LoadAsync(Stream stream, LoadOptions loadOptions, CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<XDocument>(XDocument.Load(stream, loadOptions));
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        public ValueTask SaveAsync(Stream stream, SaveOptions saveOptions, CancellationToken cancellationToken = default)
+        {
+            doc.Save(stream, saveOptions);
+            return default;
         }
     }
 

--- a/src/MiniExcel.Core/Helpers/Polyfills.cs
+++ b/src/MiniExcel.Core/Helpers/Polyfills.cs
@@ -94,12 +94,15 @@ public static class Polyfills
             _source = source;
             _continueOnCapturedContext = continueOnCapturedContext;
         }
-    
-        public ConfiguredValueTaskAwaitable DisposeAsync() 
-            => _source.DisposeAsync().ConfigureAwait(_continueOnCapturedContext);
 
-        public void Dispose() 
-            => _source?.Dispose();
+        public ConfiguredValueTaskAwaitable DisposeAsync()
+        {
+            return _source is not null 
+                ? _source.DisposeAsync().ConfigureAwait(_continueOnCapturedContext) 
+                : default;
+        }
+
+        public void Dispose() => _source?.Dispose();
     }
 #endif
 

--- a/src/MiniExcel.Core/MiniExcelDataReader.cs
+++ b/src/MiniExcel.Core/MiniExcelDataReader.cs
@@ -300,7 +300,7 @@ public sealed class MiniExcelDataReader : IMiniExcelDataReader
         }
         _source?.Dispose();
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NET
         await _stream!.DisposeAsync().ConfigureAwait(false);
 #else
         _stream.Dispose();

--- a/src/MiniExcel.Core/MiniExcelDataReader.cs
+++ b/src/MiniExcel.Core/MiniExcelDataReader.cs
@@ -294,17 +294,11 @@ public sealed class MiniExcelDataReader : IMiniExcelDataReader
         if (IsClosed)
             return;
 
-        if (_isAsyncSource)
-        {
+        if (_isAsyncSource) 
             await _asyncSource!.DisposeAsync().ConfigureAwait(false);
-        }
-        _source?.Dispose();
 
-#if NET
+        _source?.Dispose();
         await _stream!.DisposeAsync().ConfigureAwait(false);
-#else
-        _stream.Dispose();
-#endif
 
         IsClosed = true;
     }

--- a/src/MiniExcel.Core/Reflection/MiniExcelMapper.cs
+++ b/src/MiniExcel.Core/Reflection/MiniExcelMapper.cs
@@ -145,8 +145,8 @@ public static partial class MiniExcelMapper
                 else
                     throw new InvalidCastException($"{vs} cannot be cast to DateTime");
             }
-            
-#if NET6_0_OR_GREATER
+
+#if NET
             else if (map.ExcludeNullableType == typeof(DateOnly))
             {
                 if (itemValue is DateOnly)

--- a/src/MiniExcel.Csv/Api/CsvExporter.cs
+++ b/src/MiniExcel.Csv/Api/CsvExporter.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.Core;
-
 // ReSharper disable once CheckNamespace
 namespace MiniExcelLib.Csv;
 
@@ -20,7 +18,9 @@ public partial class CsvExporter
             return rowsWritten.FirstOrDefault();
         }
 
-        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, FileOptions.SequentialScan);
+        var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read, 4096, FileOptions.SequentialScan);
+        await using var disposableStream = stream.ConfigureAwait(false);
+
         return await AppendAsync(stream, value, configuration, progress, cancellationToken).ConfigureAwait(false);
     }
 
@@ -39,7 +39,9 @@ public partial class CsvExporter
     public async Task<int[]> ExportAsync(string path, object value, bool printHeader = true, bool overwriteFile = false,
         CsvConfiguration? configuration = null, IProgress<int>? progress = null, CancellationToken cancellationToken = default)
     {
-        using var stream = overwriteFile ? File.Create(path) : new FileStream(path, FileMode.CreateNew);
+        var stream = overwriteFile ? File.Create(path) : new FileStream(path, FileMode.CreateNew);
+        await using var disposableStream = stream.ConfigureAwait(false);
+
         return await ExportAsync(stream, value, printHeader, configuration, progress, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.Csv/Api/CsvImporter.cs
+++ b/src/MiniExcel.Csv/Api/CsvImporter.cs
@@ -15,7 +15,8 @@ public partial class CsvImporter
         CsvConfiguration? configuration = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         where T : class, new()
     {
-        using var stream = FileHelper.OpenSharedRead(path);
+        var stream = FileHelper.OpenSharedRead(path);
+        await using var disposableStream = stream.ConfigureAwait(false);
 
         var query = QueryAsync<T>(stream, treatHeaderAsData, configuration, cancellationToken);
         
@@ -38,7 +39,9 @@ public partial class CsvImporter
     public async IAsyncEnumerable<dynamic> QueryAsync(string path, bool useHeaderRow = false, 
         CsvConfiguration? configuration = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        using var stream = FileHelper.OpenSharedRead(path);
+        var stream = FileHelper.OpenSharedRead(path);
+        await using var disposableStream = stream.ConfigureAwait(false);
+
         await foreach (var item in QueryAsync(stream, useHeaderRow, configuration, cancellationToken).ConfigureAwait(false))
             yield return item;
     }
@@ -64,7 +67,9 @@ public partial class CsvImporter
     public async Task<DataTable> QueryAsDataTableAsync(string path, bool useHeaderRow = true,
         CsvConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-        using var stream = FileHelper.OpenSharedRead(path);
+        var stream = FileHelper.OpenSharedRead(path);
+        await using var disposableStream = stream.ConfigureAwait(false);
+
         return await QueryAsDataTableAsync(stream, useHeaderRow, configuration, cancellationToken).ConfigureAwait(false);
     }
 
@@ -127,7 +132,8 @@ public partial class CsvImporter
     public async Task<ICollection<string>> GetColumnNamesAsync(string path, bool useHeaderRow = false,
         CsvConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-        using var stream = FileHelper.OpenSharedRead(path);
+        var stream = FileHelper.OpenSharedRead(path);
+        await using var disposableStream = stream.ConfigureAwait(false);
         return await GetColumnNamesAsync(stream, useHeaderRow, configuration, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.Csv/CsvReader.cs
+++ b/src/MiniExcel.Csv/CsvReader.cs
@@ -33,7 +33,7 @@ internal partial class CsvReader : IMiniExcelReader
 
         var rowIndex = 0;
         while (await reader.ReadLineAsync(
-#if NET7_0_OR_GREATER
+#if NET
             cancellationToken
 #endif
             ).ConfigureAwait(false) is { } row)
@@ -49,7 +49,7 @@ internal partial class CsvReader : IMiniExcelReader
                 while (finalRow.Count(c => c == '"') % 2 != 0)
                 {
                     var nextPart = await reader.ReadLineAsync(
-#if NET7_0_OR_GREATER
+#if NET
                         cancellationToken
 #endif
                     ).ConfigureAwait(false);
@@ -165,6 +165,6 @@ internal partial class CsvReader : IMiniExcelReader
 
     public void Dispose()
     {
-        ((Stream?)_stream)?.Dispose();
+        _stream?.Dispose();
     }
 }

--- a/src/MiniExcel.Csv/CsvReader.cs
+++ b/src/MiniExcel.Csv/CsvReader.cs
@@ -159,7 +159,7 @@ internal partial class CsvReader : IMiniExcelReader
         
         //this code from S.O : https://stackoverflow.com/a/11365961/9131476
         return Regex.Split(row, $"[\t{_config.Seperator}](?=(?:[^\"]|\"[^\"]*\")*$)")
-            .Select(s => Regex.Replace(s.Replace("\"\"", "\""), "^\"|\"$", ""))
+            .Select(s => DoubleQuotesRegexImpl.Replace(s.Replace("\"\"", "\""), ""))
             .ToArray();
     }
 
@@ -167,4 +167,11 @@ internal partial class CsvReader : IMiniExcelReader
     {
         _stream?.Dispose();
     }
+#if NET
+    [GeneratedRegex("^\"|\"$")]
+    private static partial Regex DoubleQuotesRegex();
+    private static readonly Regex DoubleQuotesRegexImpl = DoubleQuotesRegex();
+#else
+    private static readonly Regex DoubleQuotesRegexImpl = new Regex("^\"|\"$",  RegexOptions.Compiled);
+#endif
 }

--- a/src/MiniExcel.Csv/CsvWriter.cs
+++ b/src/MiniExcel.Csv/CsvWriter.cs
@@ -60,31 +60,26 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
     
             if (mappings is null)
             {
-                await _writer.WriteAsync(_configuration.NewLine
-#if NET5_0_OR_GREATER
-                    .AsMemory(), cancellationToken
+#if NET
+                await _writer.WriteAsync(_configuration.NewLine.AsMemory(), cancellationToken).ConfigureAwait(false);
+                await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+#else
+                await _writer.WriteAsync(_configuration.NewLine).ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(false);
 #endif
-                ).ConfigureAwait(false);
-                await _writer.FlushAsync(
-#if NET8_0_OR_GREATER
-                    cancellationToken
-#endif
-                ).ConfigureAwait(false);
+
                 return 0;
             }
     
             if (_printHeader)
             {
-                await _writer.WriteAsync(GetHeader(mappings)
-#if NET5_0_OR_GREATER
-                    .AsMemory(), cancellationToken
+#if NET
+                await _writer.WriteAsync(GetHeader(mappings).AsMemory(), cancellationToken).ConfigureAwait(false);
+                await _writer.WriteAsync(newLine.AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
+                await _writer.WriteAsync(GetHeader(mappings)).ConfigureAwait(false);
+                await _writer.WriteAsync(newLine).ConfigureAwait(false);
 #endif
-                ).ConfigureAwait(false);
-                await _writer.WriteAsync(newLine
-#if NET5_0_OR_GREATER
-                    .AsMemory(), cancellationToken
-#endif
-                ).ConfigureAwait(false);
             }
             
             var rowBuilder = new StringBuilder();
@@ -103,17 +98,13 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
                     }
     
                     RemoveTrailingSeparator(rowBuilder);
-                    await _writer.WriteAsync(rowBuilder.ToString()
-#if NET5_0_OR_GREATER
-                        .AsMemory(), cancellationToken
+#if NET
+                    await _writer.WriteAsync(rowBuilder.ToString().AsMemory(), cancellationToken).ConfigureAwait(false);
+                    await _writer.WriteAsync(newLine.AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
+                    await _writer.WriteAsync(rowBuilder.ToString()).ConfigureAwait(false);
+                    await _writer.WriteAsync(newLine).ConfigureAwait(false);
 #endif
-                    ).ConfigureAwait(false);
-                    await _writer.WriteAsync(newLine
-#if NET5_0_OR_GREATER
-                        .AsMemory(), cancellationToken
-#endif
-                    ).ConfigureAwait(false);
-    
                     rowsWritten++;
                 }
             }
@@ -132,17 +123,13 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
                     }
     
                     RemoveTrailingSeparator(rowBuilder);
-                    await _writer.WriteAsync(rowBuilder.ToString()
-#if NET5_0_OR_GREATER
-                        .AsMemory(), cancellationToken
+#if NET
+                    await _writer.WriteAsync(rowBuilder.ToString().AsMemory(), cancellationToken).ConfigureAwait(false);
+                    await _writer.WriteAsync(newLine.AsMemory(), cancellationToken).ConfigureAwait(false);
+#else
+                    await _writer.WriteAsync(rowBuilder.ToString()).ConfigureAwait(false);
+                    await _writer.WriteAsync(newLine).ConfigureAwait(false);
 #endif
-                    ).ConfigureAwait(false);
-                    await _writer.WriteAsync(newLine
-#if NET5_0_OR_GREATER
-                        .AsMemory(), cancellationToken
-#endif
-                    ).ConfigureAwait(false);
-    
                     rowsWritten++;
                 }
 #endif
@@ -152,10 +139,8 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
         finally
         {
 #if !SYNC_ONLY
-            if (asyncWriteAdapter is IAsyncDisposable asyncDisposable)
-            {
-                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
-            }
+            if (asyncWriteAdapter is not null)
+                await asyncWriteAdapter.DisposeAsync().ConfigureAwait(false);
 #endif
         }
     }
@@ -170,22 +155,19 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
 
         if (_value is null)
         {
-            await _writer.WriteAsync(""
-#if NET5_0_OR_GREATER
-                .AsMemory(), cancellationToken
+#if NET
+            await _writer.WriteAsync("".AsMemory(), cancellationToken).ConfigureAwait(false);
+            await _writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+#else
+            await _writer.WriteAsync("").ConfigureAwait(false);
+            await _writer.FlushAsync().ConfigureAwait(false);
 #endif
-            ).ConfigureAwait(false);
-            await _writer.FlushAsync(
-#if NET5_0_OR_GREATER
-                cancellationToken
-#endif
-            ).ConfigureAwait(false);
             return [];
         }
 
         var rowsWritten = await WriteValuesAsync(_writer, _value, seperator, newLine, progress, cancellationToken).ConfigureAwait(false);
         await _writer.FlushAsync(
-#if NET5_0_OR_GREATER
+#if NET
             cancellationToken
 #endif
         ).ConfigureAwait(false);
@@ -200,23 +182,23 @@ internal partial class CsvWriter : IMiniExcelWriter, IDisposable
         return rowsWritten.FirstOrDefault();
     }
 
-    public string ToCsvString(object? value, MiniExcelColumnMapping? p)
+    private string ToCsvString(object? value, MiniExcelColumnMapping? mapping)
     {
         if (value is null)
             return "";
 
         if (value is DateTime dateTime)
         {
-            if (p?.ExcelFormat is not null)
-                return dateTime.ToString(p.ExcelFormat, _configuration.Culture);
+            if (mapping?.ExcelFormat is not null)
+                return dateTime.ToString(mapping.ExcelFormat, _configuration.Culture);
             
             return _configuration.Culture.Equals(CultureInfo.InvariantCulture)
                 ? dateTime.ToString("yyyy-MM-dd HH:mm:ss", _configuration.Culture)
                 : dateTime.ToString(_configuration.Culture);
         }
 
-        if (p?.ExcelFormat is not null && value is IFormattable formattableValue)
-            return formattableValue.ToString(p.ExcelFormat, _configuration.Culture);
+        if (mapping?.ExcelFormat is not null && value is IFormattable formattableValue)
+            return formattableValue.ToString(mapping.ExcelFormat, _configuration.Culture);
 
         return Convert.ToString(value, _configuration.Culture) ?? "";
     }

--- a/src/MiniExcel.OpenXml/Api/OpenXmlExporter.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlExporter.cs
@@ -36,12 +36,9 @@ public sealed partial class OpenXmlExporter
             return rowsWritten.FirstOrDefault();
         }
 
-#if NET
         var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.SequentialScan);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.SequentialScan);
-#endif
+
         return await InsertSheetAsync(stream, value, sheetName, printHeader, overwriteSheet, configuration, progress, cancellationToken).ConfigureAwait(false);
     }
 
@@ -130,16 +127,11 @@ public sealed partial class OpenXmlExporter
         if (inputFile.Equals(outputFile, StringComparison.InvariantCultureIgnoreCase))
             throw new ArgumentException("The generated file must not have the same path as the original file.");
 
-    #if NET
         var inputStream = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.RandomAccess);
         await using var disposableInputStream = inputStream.ConfigureAwait(false);
 
         var outputStream = new FileStream(outputFile, overwriteFile ? FileMode.Create : FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.SequentialScan);
         await using var disposableOutputStream = outputStream.ConfigureAwait(false);
-    #else
-        using var inputStream = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.RandomAccess);
-        using var outputStream = new FileStream(outputFile, mode: overwriteFile ? FileMode.Create : FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.SequentialScan);
-    #endif
 
         return await CopyAndAddSheetAsync(inputStream, outputStream, value, sheetName, printHeader, overwriteSheet, configuration, progress, cancellationToken).ConfigureAwait(false);
     }
@@ -164,12 +156,9 @@ public sealed partial class OpenXmlExporter
         if (Path.GetExtension(path).Equals(".xlsm", StringComparison.InvariantCultureIgnoreCase))
             throw new NotSupportedException("MiniExcel's Export does not support the .xlsm format");
 
-#if NET
         var stream = overwriteFile ? File.Create(path) : new FileStream(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = overwriteFile ? File.Create(path) : new FileStream(path, FileMode.CreateNew);
-#endif
+
         return await ExportAsync(stream, value, printHeader, sheetName, configuration, progress, cancellationToken).ConfigureAwait(false);
     }
 
@@ -210,12 +199,9 @@ public sealed partial class OpenXmlExporter
     [CreateSyncVersion]
     public async Task AlterSheetAsync(string path, string sheetName, string? newSheetName = null, int? newSheetIndex = null, SheetState? newSheetState = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
-#endif
+
         await AlterSheetAsync(stream, sheetName, newSheetName, newSheetIndex, newSheetState, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.OpenXml/Api/OpenXmlExporter.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlExporter.cs
@@ -36,7 +36,7 @@ public sealed partial class OpenXmlExporter
             return rowsWritten.FirstOrDefault();
         }
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read, 4096, FileOptions.SequentialScan);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -130,7 +130,7 @@ public sealed partial class OpenXmlExporter
         if (inputFile.Equals(outputFile, StringComparison.InvariantCultureIgnoreCase))
             throw new ArgumentException("The generated file must not have the same path as the original file.");
 
-    #if NET8_0_OR_GREATER
+    #if NET
         var inputStream = new FileStream(inputFile, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.RandomAccess);
         await using var disposableInputStream = inputStream.ConfigureAwait(false);
 
@@ -164,7 +164,7 @@ public sealed partial class OpenXmlExporter
         if (Path.GetExtension(path).Equals(".xlsm", StringComparison.InvariantCultureIgnoreCase))
             throw new NotSupportedException("MiniExcel's Export does not support the .xlsm format");
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = overwriteFile ? File.Create(path) : new FileStream(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -210,7 +210,7 @@ public sealed partial class OpenXmlExporter
     [CreateSyncVersion]
     public async Task AlterSheetAsync(string path, string sheetName, string? newSheetName = null, int? newSheetIndex = null, SheetState? newSheetState = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else

--- a/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
@@ -14,7 +14,7 @@ public sealed partial class OpenXmlImporter
         string startCell = "A1", bool treatHeaderAsData = false, OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : class, new()
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -41,7 +41,7 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -79,7 +79,7 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", string endCell = "", OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -105,7 +105,7 @@ public sealed partial class OpenXmlImporter
         int? endColumnIndex = null, OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -138,7 +138,7 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -208,7 +208,7 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<List<string>> GetSheetNamesAsync(string path, OpenXmlConfiguration? config = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -233,7 +233,7 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<List<SheetInfo>> GetSheetInformationsAsync(string path, OpenXmlConfiguration? config = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -258,7 +258,7 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<IList<ExcelRange>> GetSheetDimensionsAsync(string path, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -279,7 +279,7 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -305,7 +305,7 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<CommentResultSet> RetrieveCommentsAsync(string path, string? sheetName, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else

--- a/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
@@ -14,12 +14,9 @@ public sealed partial class OpenXmlImporter
         string startCell = "A1", bool treatHeaderAsData = false, OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : class, new()
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         var query = QueryAsync<T>(stream, sheetName, startCell, treatHeaderAsData, configuration, cancellationToken);
         
         await foreach (var item in query.ConfigureAwait(false))
@@ -41,12 +38,8 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
 
         await foreach (var item in QueryAsync(stream, useHeaderRow, sheetName, startCell, configuration, cancellationToken).ConfigureAwait(false))
             yield return item;
@@ -79,12 +72,9 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", string endCell = "", OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         await foreach (var item in QueryRangeAsync(stream, useHeaderRow, sheetName, startCell, endCell, configuration, cancellationToken).ConfigureAwait(false))
             yield return item;
     }
@@ -105,12 +95,9 @@ public sealed partial class OpenXmlImporter
         int? endColumnIndex = null, OpenXmlConfiguration? configuration = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         await foreach (var item in QueryRangeAsync(stream, useHeaderRow, sheetName, startRowIndex, startColumnIndex, endRowIndex, endColumnIndex, configuration, cancellationToken).ConfigureAwait(false))
             yield return item;
     }
@@ -138,12 +125,9 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await QueryAsDataTableAsync(stream, useHeaderRow, sheetName, startCell, configuration, cancellationToken).ConfigureAwait(false);
     }
 
@@ -208,12 +192,9 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<List<string>> GetSheetNamesAsync(string path, OpenXmlConfiguration? config = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await GetSheetNamesAsync(stream, config, cancellationToken).ConfigureAwait(false);
     }
 
@@ -233,12 +214,9 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<List<SheetInfo>> GetSheetInformationsAsync(string path, OpenXmlConfiguration? config = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await GetSheetInformationsAsync(stream, config, cancellationToken).ConfigureAwait(false);
     }
 
@@ -258,12 +236,9 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<IList<ExcelRange>> GetSheetDimensionsAsync(string path, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await GetSheetDimensionsAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -279,12 +254,9 @@ public sealed partial class OpenXmlImporter
         string? sheetName = null, string startCell = "A1", OpenXmlConfiguration? configuration = null,
         CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await GetColumnNamesAsync(stream, useHeaderRow, sheetName, startCell, configuration, cancellationToken).ConfigureAwait(false);
     }
 
@@ -305,12 +277,9 @@ public sealed partial class OpenXmlImporter
     [CreateSyncVersion]
     public async Task<CommentResultSet> RetrieveCommentsAsync(string path, string? sheetName, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = FileHelper.OpenSharedRead(path);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = FileHelper.OpenSharedRead(path);
-#endif
+
         return await RetrieveCommentsAsync(stream, sheetName, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlImporter.cs
@@ -1,4 +1,4 @@
-using MiniExcelLib.Core;
+
 
 // ReSharper disable once CheckNamespace
 namespace MiniExcelLib.OpenXml;

--- a/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
@@ -12,12 +12,9 @@ public sealed partial class OpenXmlTemplater
     [CreateSyncVersion]
     public async Task AddPictureAsync(string path, CancellationToken cancellationToken = default, params MiniExcelPicture[] images)
     {
-#if NET
         var stream = File.Open(path, FileMode.OpenOrCreate);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = File.Open(path, FileMode.OpenOrCreate);
-#endif
+
         await MiniExcelPictureImplement.AddPictureAsync(stream, cancellationToken, images).ConfigureAwait(false);
     }
 
@@ -31,12 +28,9 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, string templatePath, object value, bool overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
-#endif
+
         await FillTemplateAsync(stream, templatePath, value, configuration, cancellationToken).ConfigureAwait(false);
     }
 
@@ -44,12 +38,8 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, Stream templateStream, object value, bool  overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
-#endif
 
         var template = GetOpenXmlTemplate(stream, configuration);
         await template.SaveAsByTemplateAsync(templateStream, value, cancellationToken).ConfigureAwait(false);
@@ -75,12 +65,9 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, byte[] templateBytes, object value, bool overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = overwriteFile ? File.Create(path) :  File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = overwriteFile ? File.Create(path) :  File.Open(path, FileMode.CreateNew);
-#endif
+
         await FillTemplateAsync(stream, templateBytes, value, configuration, cancellationToken).ConfigureAwait(false);
     }
 
@@ -98,12 +85,9 @@ public sealed partial class OpenXmlTemplater
     public async Task MergeSameCellsAsync(string mergedFilePath, string path,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = File.Create(mergedFilePath);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = File.Create(mergedFilePath);
-#endif
+
         await MergeSameCellsAsync(stream, path, configuration, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
@@ -12,7 +12,7 @@ public sealed partial class OpenXmlTemplater
     [CreateSyncVersion]
     public async Task AddPictureAsync(string path, CancellationToken cancellationToken = default, params MiniExcelPicture[] images)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = File.Open(path, FileMode.OpenOrCreate);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -31,7 +31,7 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, string templatePath, object value, bool overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -44,7 +44,7 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, Stream templateStream, object value, bool  overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = overwriteFile ? File.Create(path) : File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -75,7 +75,7 @@ public sealed partial class OpenXmlTemplater
     public async Task FillTemplateAsync(string path, byte[] templateBytes, object value, bool overwriteFile = false,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = overwriteFile ? File.Create(path) :  File.Open(path, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -98,7 +98,7 @@ public sealed partial class OpenXmlTemplater
     public async Task MergeSameCellsAsync(string mergedFilePath, string path,
         OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = File.Create(mergedFilePath);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else

--- a/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
+++ b/src/MiniExcel.OpenXml/Api/OpenXmlTemplater.cs
@@ -131,48 +131,4 @@ public sealed partial class OpenXmlTemplater
     }
 
     #endregion
-
-    #region Obsolete
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(string path, string templatePath, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(path, templatePath, value, true, configuration, cancellationToken);
-    }
-
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(string path, Stream templateStream, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(path, templateStream, value, true, configuration, cancellationToken);
-    }
-    
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(Stream stream, string templatePath, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(stream, templatePath, value, configuration, cancellationToken);
-    }
-    
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(Stream stream, Stream templateStream, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(stream, templateStream, value, configuration, cancellationToken);
-    }
-    
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(string path, byte[] templateBytes, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(path, templateBytes, value, true, configuration, cancellationToken);
-    }
-    
-    [CreateSyncVersion, Obsolete("Please use FillTemplate or FillTemplateAsync instead")]
-    public Task ApplyTemplateAsync(Stream stream, byte[] templateBytes, object value,
-        OpenXmlConfiguration? configuration = null, CancellationToken cancellationToken = default)
-    {
-        return FillTemplateAsync(stream, templateBytes, value, configuration, cancellationToken);
-    }
-    #endregion
 }

--- a/src/MiniExcel.OpenXml/Api/ProviderExtensions.cs
+++ b/src/MiniExcel.OpenXml/Api/ProviderExtensions.cs
@@ -1,4 +1,4 @@
-using MiniExcelLib.Core;
+
 
 // ReSharper disable once CheckNamespace
 namespace MiniExcelLib.OpenXml;

--- a/src/MiniExcel.OpenXml/Constants/ExcelContentTypes.cs
+++ b/src/MiniExcel.OpenXml/Constants/ExcelContentTypes.cs
@@ -3,9 +3,10 @@
 internal static class ExcelContentTypes
 {
     internal const string Relationships = "application/vnd.openxmlformats-package.relationships+xml";
-    internal const string SharedStrings = "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
+    internal const string Workbook = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
     internal const string Worksheet = "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+    internal const string SharedStrings = "application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml";
     internal const string Styles = "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml";
     internal const string Drawing = "application/vnd.openxmlformats-officedocument.drawing+xml";
-    internal const string Workbook = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml";
+    internal const string Table = "application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml";
 }

--- a/src/MiniExcel.OpenXml/Constants/ExcelDataTypes.cs
+++ b/src/MiniExcel.OpenXml/Constants/ExcelDataTypes.cs
@@ -1,0 +1,12 @@
+namespace MiniExcelLib.OpenXml.Constants;
+
+internal static class ExcelDataTypes
+{
+    internal const string InlineString = "inlineStr";
+    internal const string CalculatedString = "str";
+    internal const string SharedString = "s";
+    internal const string Numeric = "n";
+    internal const string Boolean = "b";
+    internal const string DateTime = "d";
+    internal const string Error = "e";
+}

--- a/src/MiniExcel.OpenXml/Constants/ExcelFileNames.cs
+++ b/src/MiniExcel.OpenXml/Constants/ExcelFileNames.cs
@@ -11,9 +11,10 @@ internal static class ExcelFileNames
     internal const string Workbook = "xl/workbook.xml";
     internal const string WorkbookRels = "xl/_rels/workbook.xml.rels";
     internal const string WorksheetBase = "xl/worksheets/sheet";
-        
+
     internal static string Worksheet(int sheetId) => $"xl/worksheets/sheet{sheetId}.xml";
     internal static string SheetRels(int sheetId) => $"xl/worksheets/_rels/sheet{sheetId}.xml.rels";
-    internal static string Drawing(int sheetIndex) => $"xl/drawings/drawing{sheetIndex + 1}.xml";
-    internal static string DrawingRels(int sheetIndex) => $"xl/drawings/_rels/drawing{sheetIndex + 1}.xml.rels";
+    internal static string Drawing(int sheetIndex) => $"xl/drawings/drawing{sheetIndex}.xml";
+    internal static string DrawingRels(int sheetIndex) => $"xl/drawings/_rels/drawing{sheetIndex}.xml.rels";
+    internal static string Table(int tableIndex) => $"xl/tables/table{tableIndex}.xml";
 }

--- a/src/MiniExcel.OpenXml/Constants/ExcelFileNames.cs
+++ b/src/MiniExcel.OpenXml/Constants/ExcelFileNames.cs
@@ -8,6 +8,8 @@ internal static class ExcelFileNames
     internal const string ContentTypes = "[Content_Types].xml";
     internal const string Person = "xl/persons/person.xml";
     internal const string Styles = "xl/styles.xml";
+    internal const string CalcChain = "xl/calcChain.xml";
+
     internal const string Workbook = "xl/workbook.xml";
     internal const string WorkbookRels = "xl/_rels/workbook.xml.rels";
     internal const string WorksheetBase = "xl/worksheets/sheet";

--- a/src/MiniExcel.OpenXml/Constants/ExcelXml.cs
+++ b/src/MiniExcel.OpenXml/Constants/ExcelXml.cs
@@ -11,12 +11,6 @@ internal static class ExcelXml
         DefaultDrawing = XmlHelper.MinifyXml(DefaultDrawing);
     }
 
-    internal const string InlineStringDataType = "inlineStr";
-    internal const string CalculatedStringDataType = "str";
-    internal const string SharedStringDataType = "s";
-    internal const string NumericDataType = "n";
-    internal const string BooleanDataType = "b";
-
     internal const string EmptySheetXml = """<?xml version="1.0" encoding="utf-8"?><x:worksheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:dimension ref="A1"/><x:sheetData></x:sheetData></x:worksheet>""";
 
     internal static readonly string DefaultRels = 

--- a/src/MiniExcel.OpenXml/Constants/Schemas.cs
+++ b/src/MiniExcel.OpenXml/Constants/Schemas.cs
@@ -8,9 +8,14 @@ internal static class Schemas
     public const string OpenXmlPackageRelationships = "http://schemas.openxmlformats.org/package/2006/relationships";
     public const string SpreadsheetmlXmlRelationships = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
     public const string SpreadsheetmlXmlStrictRelationships = "http://purl.oclc.org/ooxml/officeDocument/relationships";
-    public const string SpreadsheetmlXmlTable = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
-    public const string SpreadsheetmlXmlComments = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments";
-    public const string SpreadsheetmlXmlThreadedComment = "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment";
+    public const string SpreadsheetmlXmlSpreadsheetDrawing = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
+    public const string SpreadsheetmlXmlDrawingml2006 = "http://schemas.openxmlformats.org/drawingml/2006/main";
+    public const string SpreadsheetmlXmlDrawing2014 = "http://schemas.microsoft.com/office/drawing/2014/main";
+    public const string SpreadsheetmlXmlDrawingRelationship = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing";
+    public const string SpreadsheetmlXmlImageRelationship = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+    public const string SpreadsheetmlXmlTableRelationship = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
+    public const string SpreadsheetmlXmlCommentsRelationship = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments";
+    public const string SpreadsheetmlXmlThreadedCommentRelationship = "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment";
 
     public const string SpreadsheetmlXmlX14Ac = "http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac";
     public const string SpreadsheetmlXmlX18Tc = "http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments";

--- a/src/MiniExcel.OpenXml/Constants/Schemas.cs
+++ b/src/MiniExcel.OpenXml/Constants/Schemas.cs
@@ -8,6 +8,7 @@ internal static class Schemas
     public const string OpenXmlPackageRelationships = "http://schemas.openxmlformats.org/package/2006/relationships";
     public const string SpreadsheetmlXmlRelationships = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
     public const string SpreadsheetmlXmlStrictRelationships = "http://purl.oclc.org/ooxml/officeDocument/relationships";
+    public const string SpreadsheetmlXmlTable = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/table";
     public const string SpreadsheetmlXmlComments = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/comments";
     public const string SpreadsheetmlXmlThreadedComment = "http://schemas.microsoft.com/office/2017/10/relationships/threadedComment";
 

--- a/src/MiniExcel.OpenXml/Constants/WorksheetXml.cs
+++ b/src/MiniExcel.OpenXml/Constants/WorksheetXml.cs
@@ -1,6 +1,4 @@
-﻿using MiniExcelLib.Core.Attributes;
-
-namespace MiniExcelLib.OpenXml.Constants;
+﻿namespace MiniExcelLib.OpenXml.Constants;
 
 internal static class WorksheetXml
 {

--- a/src/MiniExcel.OpenXml/Constants/WorksheetXml.cs
+++ b/src/MiniExcel.OpenXml/Constants/WorksheetXml.cs
@@ -57,13 +57,13 @@ internal static class WorksheetXml
         return cellType switch
         {
             _ when columnType == ColumnType.Formula 
-                => $"""<x:c r="{cellReference}" t="{ExcelXml.CalculatedStringDataType}" s="{styleIndex}"{(preserveSpace ? " xml:space=\"preserve\"" : "")}><x:f>{XmlHelper.EncodeXml(cellValue)}</x:f></x:c>""", 
+                => $"""<x:c r="{cellReference}" t="{ExcelDataTypes.CalculatedString}" s="{styleIndex}"{(preserveSpace ? " xml:space=\"preserve\"" : "")}><x:f>{XmlHelper.EncodeXml(cellValue)}</x:f></x:c>""", 
             
-            ExcelXml.InlineStringDataType
-                => $"""<x:c r="{cellReference}" t="{ExcelXml.InlineStringDataType}" s="{styleIndex}"><x:is><x:t{(preserveSpace ? " xml:space=\"preserve\"" : "")}>{XmlHelper.EncodeXml(cellValue)}</x:t></x:is></x:c>""",
+            ExcelDataTypes.InlineString
+                => $"""<x:c r="{cellReference}" t="{ExcelDataTypes.InlineString}" s="{styleIndex}"><x:is><x:t{(preserveSpace ? " xml:space=\"preserve\"" : "")}>{XmlHelper.EncodeXml(cellValue)}</x:t></x:is></x:c>""",
 
-            ExcelXml.SharedStringDataType
-                => $"""<x:c r="{cellReference}" t="{ExcelXml.SharedStringDataType}" s="{styleIndex}"><x:v>{cellValue}</x:v></x:c>""",
+            ExcelDataTypes.SharedString
+                => $"""<x:c r="{cellReference}" t="{ExcelDataTypes.SharedString}" s="{styleIndex}"><x:v>{cellValue}</x:v></x:c>""",
             
             _ => $"""<x:c r="{cellReference}" t="{cellType}" s="{styleIndex}"><x:v>{cellValue}</x:v></x:c>"""
         };

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingExporter.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingExporter.cs
@@ -19,12 +19,8 @@ public sealed partial class MappingExporter
     {
         var filePath = path.EndsWith(".xlsx",  StringComparison.InvariantCultureIgnoreCase) ? path : $"{path}.xlsx" ;
 
-#if NET
         var stream = overwriteFile ? File.Create(filePath) : new FileStream(filePath, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = overwriteFile ? File.Create(filePath) : new FileStream(filePath, FileMode.CreateNew);
-#endif
 
         await ExportAsync(stream, values, cancellationToken).ConfigureAwait(false);
     }

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingExporter.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingExporter.cs
@@ -19,7 +19,7 @@ public sealed partial class MappingExporter
     {
         var filePath = path.EndsWith(".xlsx",  StringComparison.InvariantCultureIgnoreCase) ? path : $"{path}.xlsx" ;
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = overwriteFile ? File.Create(filePath) : new FileStream(filePath, FileMode.CreateNew);
         await using var disposableStream = stream.ConfigureAwait(false);
 #else

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingImporter.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingImporter.cs
@@ -12,7 +12,7 @@ public sealed partial class MappingImporter()
     [CreateSyncVersion]
     public async IAsyncEnumerable<T> QueryAsync<T>(string path, [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : class, new()
     {
-    #if NET8_0_OR_GREATER
+    #if NET
         var stream = File.OpenRead(path);
         await using var disposableStream = stream.ConfigureAwait(false);
     #else
@@ -39,7 +39,7 @@ public sealed partial class MappingImporter()
     [CreateSyncVersion]
     public async Task<T> QuerySingleAsync<T>(string path, CancellationToken cancellationToken = default) where T : class, new()
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = File.OpenRead(path);
         await using var disposableStream = stream.ConfigureAwait(false);
 #else

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingImporter.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingImporter.cs
@@ -12,12 +12,8 @@ public sealed partial class MappingImporter()
     [CreateSyncVersion]
     public async IAsyncEnumerable<T> QueryAsync<T>(string path, [EnumeratorCancellation] CancellationToken cancellationToken = default) where T : class, new()
     {
-    #if NET
         var stream = File.OpenRead(path);
         await using var disposableStream = stream.ConfigureAwait(false);
-    #else
-        using var stream = File.OpenRead(path);
-    #endif
 
         await foreach (var item in QueryAsync<T>(stream, cancellationToken).ConfigureAwait(false))
             yield return item;
@@ -39,12 +35,9 @@ public sealed partial class MappingImporter()
     [CreateSyncVersion]
     public async Task<T> QuerySingleAsync<T>(string path, CancellationToken cancellationToken = default) where T : class, new()
     {
-#if NET
         var stream = File.OpenRead(path);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = File.OpenRead(path);
-#endif
+
         return await QuerySingleAsync<T>(stream, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingTemplater.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingTemplater.cs
@@ -23,16 +23,12 @@ public sealed partial class MappingTemplater()
         if (values is null)
             throw new ArgumentNullException(nameof(values));
 
-#if NET
         var outputStream = File.Create(outputPath);
         await using var disposableOutputStream = outputStream.ConfigureAwait(false);
         
         var templateStream = File.OpenRead(templatePath);
         await using var disposableTemplateStream = templateStream.ConfigureAwait(false);
-#else
-        using var outputStream = File.Create(outputPath);
-        using var templateStream = File.OpenRead(templatePath);
-#endif
+
         await FillTemplateAsync(outputStream, templateStream, values, cancellationToken).ConfigureAwait(false);
     }
 
@@ -73,12 +69,9 @@ public sealed partial class MappingTemplater()
         if (values is null)
             throw new ArgumentNullException(nameof(values));
 
-#if NET
         var templateStream = new MemoryStream(templateBytes);
         await using var disposableTemplateStream = templateStream.ConfigureAwait(false);
-#else
-        using var templateStream = new MemoryStream(templateBytes);
-#endif
+
         await FillTemplateAsync(outputStream, templateStream, values, cancellationToken).ConfigureAwait(false);
     }
 
@@ -115,3 +108,4 @@ public Task ApplyTemplateAsync<T>(
 }
 #endregion
 }
+

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/MappingTemplater.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/MappingTemplater.cs
@@ -23,7 +23,7 @@ public sealed partial class MappingTemplater()
         if (values is null)
             throw new ArgumentNullException(nameof(values));
 
-#if NET8_0_OR_GREATER
+#if NET
         var outputStream = File.Create(outputPath);
         await using var disposableOutputStream = outputStream.ConfigureAwait(false);
         
@@ -73,7 +73,7 @@ public sealed partial class MappingTemplater()
         if (values is null)
             throw new ArgumentNullException(nameof(values));
 
-#if NET8_0_OR_GREATER
+#if NET
         var templateStream = new MemoryStream(templateBytes);
         await using var disposableTemplateStream = templateStream.ConfigureAwait(false);
 #else

--- a/src/MiniExcel.OpenXml/FluentMapping/Api/ProviderExtensions.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Api/ProviderExtensions.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.Core;
-
 namespace MiniExcelLib.OpenXml.FluentMapping.Api;
 
 public static class ProviderExtensions

--- a/src/MiniExcel.OpenXml/FluentMapping/CompiledMapping.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/CompiledMapping.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-
 namespace MiniExcelLib.OpenXml.FluentMapping;
 
 internal class CompiledMapping<T>

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/CollectionMappingBuilder.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/CollectionMappingBuilder.cs
@@ -5,7 +5,7 @@ namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;
 
 internal partial class CollectionMappingBuilder<T, TCollection> : ICollectionMappingBuilder<T, TCollection> where TCollection : IEnumerable
 {
-#if NET7_0_OR_GREATER
+#if NET
     [GeneratedRegex("^[A-Z]+[0-9]+$")] private static partial Regex CellAddressRegexImpl();
     private static readonly Regex CellAddressRegex = CellAddressRegexImpl();
 #else

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/CollectionMappingBuilder.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/CollectionMappingBuilder.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Text.RegularExpressions;
 
 namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/ICollectionMappingBuilder.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/ICollectionMappingBuilder.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-
 namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;
 
 public interface ICollectionMappingBuilder<T, TCollection> where TCollection : IEnumerable

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/IMappingConfiguration.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/IMappingConfiguration.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Linq.Expressions;
-
 namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;
 
 public interface IMappingConfiguration<T>

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/MappingConfiguration.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/MappingConfiguration.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Linq.Expressions;
-
 namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;
 
 internal class MappingConfiguration<T> : IMappingConfiguration<T>

--- a/src/MiniExcel.OpenXml/FluentMapping/Configuration/PropertyMappingBuilder.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Configuration/PropertyMappingBuilder.cs
@@ -4,7 +4,7 @@ namespace MiniExcelLib.OpenXml.FluentMapping.Configuration;
 
 internal partial class PropertyMappingBuilder<T, TProperty> : IPropertyMappingBuilder<T, TProperty>
 {
-#if NET7_0_OR_GREATER
+#if NET
     [GeneratedRegex("^[A-Z]+[0-9]+$")] private static partial Regex CellAddressRegexImpl();
     private static readonly Regex CellAddressRegex = CellAddressRegexImpl();
 #else

--- a/src/MiniExcel.OpenXml/FluentMapping/Helpers/ConversionHelper.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Helpers/ConversionHelper.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Globalization;
-using System.Linq.Expressions;
 using System.Reflection;
 
 namespace MiniExcelLib.OpenXml.FluentMapping.Helpers;

--- a/src/MiniExcel.OpenXml/FluentMapping/Helpers/MappingMetadataExtractor.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/Helpers/MappingMetadataExtractor.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Reflection;
 using MiniExcelLib.Core.Helpers;
 using MiniExcelLib.Core.Reflection;

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingCellStream.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingCellStream.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using MiniExcelLib.Core.Abstractions;
 
 namespace MiniExcelLib.OpenXml.FluentMapping;

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingCompiler.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingCompiler.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Linq.Expressions;
 using System.Reflection;
 using MiniExcelLib.Core.Helpers;
 using MiniExcelLib.Core.Reflection;

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingReader.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingReader.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Runtime.CompilerServices;
 using Zomp.SyncMethodGenerator;
 

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.OpenXml.Constants;
-
 namespace MiniExcelLib.OpenXml.FluentMapping;
 
 internal static partial class MappingTemplateApplicator<T> where T : class

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
@@ -24,11 +24,11 @@ internal static partial class MappingTemplateApplicator<T> where T : class
         {
             // Copy to memory stream if not seekable
             var memStream = new MemoryStream();
-#if NETCOREAPP2_1_OR_GREATER
-            await templateStream.CopyToAsync(memStream, cancellationToken).ConfigureAwait(false);
-#else
-            await templateStream.CopyToAsync(memStream).ConfigureAwait(false);
+            await templateStream.CopyToAsync(memStream
+#if NET
+                , cancellationToken
 #endif
+            ).ConfigureAwait(false);
             memStream.Position = 0;
             templateStream = memStream;
         }
@@ -111,7 +111,7 @@ internal static partial class MappingTemplateApplicator<T> where T : class
         targetEntry.LastWriteTime = sourceEntry.LastWriteTime;
         
         // Copy content
-#if NET8_0_OR_GREATER
+#if NET
         var sourceStream = await sourceEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 
@@ -141,7 +141,7 @@ internal static partial class MappingTemplateApplicator<T> where T : class
         targetEntry.LastWriteTime = sourceEntry.LastWriteTime;
         
         // Open streams
-#if NET8_0_OR_GREATER
+#if NET
         var sourceStream = await sourceEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
@@ -1,3 +1,5 @@
+using MiniExcelLib.OpenXml.Constants;
+
 namespace MiniExcelLib.OpenXml.FluentMapping;
 
 internal static partial class MappingTemplateApplicator<T> where T : class
@@ -88,7 +90,7 @@ internal static partial class MappingTemplateApplicator<T> where T : class
     
     private static bool IsWorksheetEntry(string fullName)
     {
-        return fullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) &&
+        return fullName.StartsWith(ExcelFileNames.WorksheetBase, StringComparison.OrdinalIgnoreCase) &&
                fullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase);
     }
     

--- a/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/MappingTemplateApplicator.cs
@@ -113,20 +113,13 @@ internal static partial class MappingTemplateApplicator<T> where T : class
         targetEntry.LastWriteTime = sourceEntry.LastWriteTime;
         
         // Copy content
-#if NET
         var sourceStream = await sourceEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         await using var disposableSourceStream = sourceStream.ConfigureAwait(false);
+
+        var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableTargetStream = targetStream.ConfigureAwait(false);
 
-        await sourceStream.CopyToAsync(targetStream, cancellationToken).ConfigureAwait(false);
-#else
-        using var sourceStream = sourceEntry.Open();
-        using var targetStream = targetEntry.Open();
-
-        await sourceStream.CopyToAsync(targetStream).ConfigureAwait(false);
-#endif
+        await sourceStream.CopyToAsync(targetStream, 81920, cancellationToken).ConfigureAwait(false);
     }
     
     [CreateSyncVersion]
@@ -143,16 +136,11 @@ internal static partial class MappingTemplateApplicator<T> where T : class
         targetEntry.LastWriteTime = sourceEntry.LastWriteTime;
         
         // Open streams
-#if NET
         var sourceStream = await sourceEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-        var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-
         await using var disposableSourceStream = sourceStream.ConfigureAwait(false);
+
+        var targetStream = await targetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableTargetStream = targetStream.ConfigureAwait(false);
-#else
-        using var sourceStream = sourceEntry.Open();
-        using var targetStream = targetEntry.Open();
-#endif
         
         // Create processor for this worksheet
         var processor = new MappingTemplateProcessor<T>(mapping);

--- a/src/MiniExcel.OpenXml/FluentMapping/NestedMappingInfo.cs
+++ b/src/MiniExcel.OpenXml/FluentMapping/NestedMappingInfo.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-
 namespace MiniExcelLib.OpenXml.FluentMapping;
 
 /// <summary>

--- a/src/MiniExcel.OpenXml/GlobalUsings.cs
+++ b/src/MiniExcel.OpenXml/GlobalUsings.cs
@@ -1,17 +1,24 @@
 // Global using directives
 
 global using System.Collections;
+global using System.ComponentModel;
 global using System.Data;
 global using System.Globalization;
 global using System.IO.Compression;
+global using System.Linq.Expressions;
 global using System.Reflection;
 global using System.Runtime.CompilerServices;
 global using System.Text;
 global using System.Text.RegularExpressions;
 global using System.Xml;
+global using System.Xml.Linq;
+global using MiniExcelLib.Core;
 global using MiniExcelLib.Core.Abstractions;
+global using MiniExcelLib.Core.Attributes;
+global using MiniExcelLib.Core.Enums;
 global using MiniExcelLib.Core.Helpers;
 global using MiniExcelLib.Core.Reflection;
+global using MiniExcelLib.OpenXml.Constants;
 global using MiniExcelLib.OpenXml.Helpers;
 global using MiniExcelLib.OpenXml.Models;
 global using MiniExcelLib.OpenXml.Utils;

--- a/src/MiniExcel.OpenXml/Helpers/XmlHelper.cs
+++ b/src/MiniExcel.OpenXml/Helpers/XmlHelper.cs
@@ -3,7 +3,7 @@
 /// <summary> XmlEncoder MIT Copyright ©2021 from https://github.com/ClosedXML </summary>
 internal static partial class XmlHelper
 {
-#if NET7_0_OR_GREATER
+#if NET
     [GeneratedRegex("_(x[\\dA-Fa-f]{4})_", RegexOptions.Compiled)] private static partial Regex X4LRegexImpl();
     private static readonly Regex X4LRegex = X4LRegexImpl();
     

--- a/src/MiniExcel.OpenXml/Models/SheetDto.cs
+++ b/src/MiniExcel.OpenXml/Models/SheetDto.cs
@@ -1,11 +1,13 @@
-﻿namespace MiniExcelLib.OpenXml.Models;
+﻿using MiniExcelLib.OpenXml.Constants;
+
+namespace MiniExcelLib.OpenXml.Models;
 
 internal class SheetDto
 {
     internal string ID { get; set; } = $"R{Guid.NewGuid():N}";
     internal string? Name { get; set; }
     internal int SheetIdx { get; set; }
-    internal string Path => $"xl/worksheets/sheet{SheetIdx}.xml";
+    internal string Path => ExcelFileNames.Worksheet(SheetIdx);
 
     internal string State { get; set; }
 }

--- a/src/MiniExcel.OpenXml/Models/SheetDto.cs
+++ b/src/MiniExcel.OpenXml/Models/SheetDto.cs
@@ -1,6 +1,4 @@
-﻿using MiniExcelLib.OpenXml.Constants;
-
-namespace MiniExcelLib.OpenXml.Models;
+﻿namespace MiniExcelLib.OpenXml.Models;
 
 internal class SheetDto
 {

--- a/src/MiniExcel.OpenXml/OpenXmlConfiguration.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlConfiguration.cs
@@ -1,4 +1,3 @@
-using MiniExcelLib.Core;
 using MiniExcelLib.OpenXml.Styles;
 
 namespace MiniExcelLib.OpenXml;

--- a/src/MiniExcel.OpenXml/OpenXmlReader.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlReader.cs
@@ -178,12 +178,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
             maxColumnIndex = endColumnIndex.Value;
         }
 
-#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
-#else
-        using var sheetStream = sheetEntry.Open();
-#endif
+
         using var reader = XmlReader.Create(sheetStream, xmlSettings);
 
         if (!reader.IsStartElement("worksheet", Ns))
@@ -417,13 +414,10 @@ internal partial class OpenXmlReader : IMiniExcelReader
         if (Archive.GetEntry(ExcelFileNames.SharedStrings) is not { } sharedStringsEntry)
             return;
         
-        var idx = 0;
-#if NET
         var stream = await sharedStringsEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = sharedStringsEntry.Open();
-#endif
+
+        var idx = 0;
         if (_config.EnableSharedStringCache && sharedStringsEntry.Length >= _config.SharedStringCacheSize)
         {
             SharedStrings = new SharedStringsDiskCache(_config.SharedStringCachePath);
@@ -459,12 +453,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
         );
 
         var entry = entries.Single(w => w.FullName == ExcelFileNames.Workbook);
-#if NET
         var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = entry.Open();
-#endif
+
         using var reader = XmlReader.Create(stream, xmlSettings);
         
         if (!reader.IsStartElement("workbook", Ns))
@@ -522,7 +513,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
                         sheetCount++;
                         await reader.SkipAsync()
 #if NET
-                                .WaitAsync(cancellationToken)
+                            .WaitAsync(cancellationToken)
 #endif
                             .ConfigureAwait(false);
                     }
@@ -556,12 +547,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         var entry = entries.Single(w => w.FullName == ExcelFileNames.WorkbookRels);
         
-#if NET
         var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = entry.Open();
-#endif
+
         using var reader = XmlReader.Create(stream, xmlSettings);
         
         if (!XmlReaderHelper.IsStartElement(reader, "Relationships", Schemas.OpenXmlPackageRelationships))
@@ -758,12 +746,8 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
             var withoutCr = false;
 
-#if NET
             var crSheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableCrSheetStream = crSheetStream.ConfigureAwait(false);
-#else
-            using var crSheetStream = sheet.Open();
-#endif
             using (var reader = XmlReader.Create(crSheetStream, xmlSettings))
             {
                 while (await reader.ReadAsync().ConfigureAwait(false))
@@ -811,12 +795,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
             if (withoutCr)
             {
-#if NET
                 var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
                 await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
-#else
-                using var sheetStream = sheet.Open();
-#endif
+
                 using var reader = XmlReader.Create(sheetStream, xmlSettings);
                 
                 if (!reader.IsStartElement("worksheet", Ns))
@@ -911,12 +892,8 @@ internal partial class OpenXmlReader : IMiniExcelReader
         int maxRowIndex = -1;
         int maxColumnIndex = -1;
 
-#if NET
         var crSheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableCrSheetStream  = crSheetStream.ConfigureAwait(false);
-#else
-        using var crSheetStream = sheetEntry.Open();
-#endif
         using (var reader = XmlReader.Create(crSheetStream, xmlSettings))
         {
             while (await reader.ReadAsync()
@@ -966,12 +943,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         if (withoutCr)
         {
-#if NET
             var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
-#else
-            using var sheetStream = sheetEntry.Open();
-#endif
+
             using var reader = XmlReader.Create(sheetStream, xmlSettings);
             
             if (!reader.IsStartElement("worksheet", Ns))
@@ -1046,12 +1020,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
         );
         var mergeCells = new MergeCells();
 
-#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await  using var disposableSheetStream = sheetStream.ConfigureAwait(false);
-#else
-        using var sheetStream = sheetEntry.Open();
-#endif
+
         using var reader = XmlReader.Create(sheetStream, xmlSettings);
         
         if (!reader.IsStartElement("worksheet", Ns))
@@ -1123,12 +1094,8 @@ internal partial class OpenXmlReader : IMiniExcelReader
         List<Author> people = [];
         if (Archive.GetEntry(ExcelFileNames.Person) is { } persons)
         {
-#if NET
             var personStream = await persons.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposablePersonStream = personStream.ConfigureAwait(false);  
-#else
-            using var personStream = persons.Open();
-#endif
             
             var personDoc = await XDocument.LoadAsync(personStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
             var personElements = personDoc.Root?.Elements(ns18Tc + "person");
@@ -1145,12 +1112,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
         if (Archive.GetEntry($"xl/worksheets/_rels/{sheetFile}.rels") is not { } rel)
             return new CommentResultSet(sheetName, [], []);
 
-#if NET
         var stream = await rel.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);  
-#else
-        using var stream = rel.Open();
-#endif
+
         var relDoc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
         var threadedCommentRels = relDoc.Root?.Elements(nsRel + "Relationship");
@@ -1168,12 +1132,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
         HashSet<string?> refCells = [];
         if (Archive.GetEntry($"xl/{threadedCommentsPath}") is { } threadEntry)
         {
-#if NET
             var threadEntryStream = await threadEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableThreadEntryStream = threadEntryStream.ConfigureAwait(false);
-#else
-            using var threadEntryStream = threadEntry.Open();
-#endif
+
             var doc = await XDocument.LoadAsync(threadEntryStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
             var commentThreadElements = doc.Root?.Elements(ns18Tc + "threadedComment");
@@ -1216,12 +1177,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         if (Archive.GetEntry($"xl/{notesPath}") is { } noteEntry)
         {
-#if NET
             var noteEntryStream = await noteEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableNoteEntryStream = noteEntryStream.ConfigureAwait(false);
-#else
-            using var noteEntryStream = noteEntry.Open();
-#endif
+
             var doc = await XDocument.LoadAsync(noteEntryStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
             var authorElements = doc.Root?.Element(nsMain + "authors")?.Elements(nsMain + "author");
@@ -1283,12 +1241,9 @@ internal partial class OpenXmlReader : IMiniExcelReader
             Async = true
         };
 
-#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
-#else
-        using var sheetStream = sheetEntry.Open();
-#endif
+
         using var reader = XmlReader.Create(sheetStream, xmlSettings);
         
         if (!reader.IsStartElement("worksheet", Ns))

--- a/src/MiniExcel.OpenXml/OpenXmlReader.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlReader.cs
@@ -178,7 +178,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
             maxColumnIndex = endColumnIndex.Value;
         }
 
-#if NET8_0_OR_GREATER
+#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 #else
@@ -418,7 +418,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
             return;
         
         var idx = 0;
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await sharedStringsEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
 #else
@@ -459,7 +459,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         );
 
         var entry = entries.Single(w => w.FullName == ExcelFileNames.Workbook);
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
 #else
@@ -491,7 +491,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
                         }
 
                         await reader.SkipAsync()
-#if NET6_0_OR_GREATER
+#if NET
                             .WaitAsync(cancellationToken)
 #endif
                             .ConfigureAwait(false);
@@ -521,7 +521,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
                         );
                         sheetCount++;
                         await reader.SkipAsync()
-#if NET6_0_OR_GREATER
+#if NET
                                 .WaitAsync(cancellationToken)
 #endif
                             .ConfigureAwait(false);
@@ -556,7 +556,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         var entry = entries.Single(w => w.FullName == ExcelFileNames.WorkbookRels);
         
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
 #else
@@ -581,7 +581,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
                 }
 
                 await reader.SkipAsync()
-#if NET6_0_OR_GREATER
+#if NET
                     .WaitAsync(cancellationToken)
 #endif
                     .ConfigureAwait(false);
@@ -648,7 +648,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
             if (reader.IsStartElement("v", Ns))
             {
                 var rawValue = await reader.ReadElementContentAsStringAsync()
-#if NET6_0_OR_GREATER
+#if NET
                     .WaitAsync(cancellationToken)
 #endif
                     .ConfigureAwait(false);
@@ -759,7 +759,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
             var withoutCr = false;
 
-#if NET8_0_OR_GREATER
+#if NET
             var crSheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableCrSheetStream = crSheetStream.ConfigureAwait(false);
 #else
@@ -812,7 +812,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
             if (withoutCr)
             {
-#if NET8_0_OR_GREATER
+#if NET
                 var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
                 await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 #else
@@ -912,7 +912,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         int maxRowIndex = -1;
         int maxColumnIndex = -1;
 
-#if NET8_0_OR_GREATER
+#if NET
         var crSheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableCrSheetStream  = crSheetStream.ConfigureAwait(false);
 #else
@@ -921,7 +921,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         using (var reader = XmlReader.Create(crSheetStream, xmlSettings))
         {
             while (await reader.ReadAsync()
-#if NET6_0_OR_GREATER
+#if NET
                 .WaitAsync(cancellationToken)
 #endif
                 .ConfigureAwait(false))
@@ -967,7 +967,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         if (withoutCr)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 #else
@@ -1047,7 +1047,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         );
         var mergeCells = new MergeCells();
 
-#if NET8_0_OR_GREATER
+#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await  using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 #else
@@ -1124,7 +1124,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         List<Author> people = [];
         if (Archive.GetEntry(ExcelFileNames.Person) is { } persons)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var personStream = await persons.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposablePersonStream = personStream.ConfigureAwait(false);  
 #else
@@ -1150,7 +1150,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         if (Archive.GetEntry($"xl/worksheets/_rels/{sheetFile}.rels") is not { } rel)
             return new CommentResultSet(sheetName, [], []);
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await rel.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);  
 #else
@@ -1178,7 +1178,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         HashSet<string?> refCells = [];
         if (Archive.GetEntry($"xl/{threadedCommentsPath}") is { } threadEntry)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var threadEntryStream = await threadEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableThreadEntryStream = threadEntryStream.ConfigureAwait(false);
 #else
@@ -1231,7 +1231,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 
         if (Archive.GetEntry($"xl/{notesPath}") is { } noteEntry)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var noteEntryStream = await noteEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableNoteEntryStream = noteEntryStream.ConfigureAwait(false);
 #else
@@ -1303,7 +1303,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
             Async = true
         };
 
-#if NET8_0_OR_GREATER
+#if NET
         var sheetStream = await sheetEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 #else

--- a/src/MiniExcel.OpenXml/OpenXmlReader.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlReader.cs
@@ -679,7 +679,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
         
         switch (aT)
         {
-            case "s":
+            case ExcelDataTypes.SharedString:
                 if (int.TryParse(rawValue, style, invariantCulture, out var sstIndex))
                 {
                     if (sstIndex >= 0 && sstIndex < SharedStrings?.Count)
@@ -689,8 +689,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
                 }
                 break;
 
-            case "inlineStr":
-            case "str":
+            case ExcelDataTypes.InlineString or ExcelDataTypes.CalculatedString:
                 //TODO: it will unbox,box
                 var v = XmlHelper.DecodeString(rawValue);
                 value = v;
@@ -711,17 +710,17 @@ internal partial class OpenXmlReader : IMiniExcelReader
                 }
                 break;
 
-            case "b":
+            case ExcelDataTypes.Boolean:
                 value = rawValue == "1";
                 return;
 
-            case "d":
+            case ExcelDataTypes.DateTime:
                 value = DateTime.TryParseExact(rawValue, "yyyy-MM-dd", invariantCulture, DateTimeStyles.AllowLeadingWhite | DateTimeStyles.AllowTrailingWhite, out var date)
                     ? date
                     : rawValue;
                 return;
 
-            case "e":
+            case ExcelDataTypes.Error:
                 value = rawValue;
                 return;
 
@@ -1155,12 +1154,12 @@ internal partial class OpenXmlReader : IMiniExcelReader
         var relDoc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
         var threadedCommentRels = relDoc.Root?.Elements(nsRel + "Relationship");
-        var threadedCommentsElement = threadedCommentRels?.FirstOrDefault(x => x.Attribute("Type")?.Value == Schemas.SpreadsheetmlXmlThreadedComment);
+        var threadedCommentsElement = threadedCommentRels?.FirstOrDefault(x => x.Attribute("Type")?.Value == Schemas.SpreadsheetmlXmlThreadedCommentRelationship);
         var threadedCommentsTarget = threadedCommentsElement?.Attribute("Target");
         var threadedCommentsPath = threadedCommentsTarget?.Value.TrimStart('.', '/');
 
         var noteRels = relDoc.Root?.Elements(nsRel + "Relationship");
-        var notesElement = noteRels?.FirstOrDefault(x => x.Attribute("Type")?.Value == Schemas.SpreadsheetmlXmlComments);
+        var notesElement = noteRels?.FirstOrDefault(x => x.Attribute("Type")?.Value == Schemas.SpreadsheetmlXmlCommentsRelationship);
         var notesTarget = notesElement?.Attribute("Target");
         var notesPath = notesTarget?.Value.TrimStart('.', '/');
 

--- a/src/MiniExcel.OpenXml/OpenXmlReader.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlReader.cs
@@ -1131,11 +1131,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
             using var personStream = persons.Open();
 #endif
             
-#if NETSTANDARD2_0
-            var personDoc = XDocument.Load(personStream, LoadOptions.None);
-#else
             var personDoc = await XDocument.LoadAsync(personStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
-#endif
             var personElements = personDoc.Root?.Elements(ns18Tc + "person");
             people = personElements
                 ?.Select(p => new Author
@@ -1156,12 +1152,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 #else
         using var stream = rel.Open();
 #endif
-        
-#if NETSTANDARD2_0
-        var relDoc = XDocument.Load(stream, LoadOptions.None);
-#else
         var relDoc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
-#endif
 
         var threadedCommentRels = relDoc.Root?.Elements(nsRel + "Relationship");
         var threadedCommentsElement = threadedCommentRels?.FirstOrDefault(x => x.Attribute("Type")?.Value == Schemas.SpreadsheetmlXmlThreadedComment);
@@ -1184,12 +1175,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 #else
             using var threadEntryStream = threadEntry.Open();
 #endif
-
-#if NETSTANDARD2_0
-            var doc = XDocument.Load(threadEntryStream, LoadOptions.None);
-#else
             var doc = await XDocument.LoadAsync(threadEntryStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
-#endif
 
             var commentThreadElements = doc.Root?.Elements(ns18Tc + "threadedComment");
             commentThreads = commentThreadElements
@@ -1237,12 +1223,7 @@ internal partial class OpenXmlReader : IMiniExcelReader
 #else
             using var noteEntryStream = noteEntry.Open();
 #endif
-
-#if NETSTANDARD2_0
-            var doc = XDocument.Load(noteEntryStream, LoadOptions.None);
-#else
             var doc = await XDocument.LoadAsync(noteEntryStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
-#endif
 
             var authorElements = doc.Root?.Element(nsMain + "authors")?.Elements(nsMain + "author");
             var authors = authorElements?.Select(a => a.Value).ToArray();

--- a/src/MiniExcel.OpenXml/OpenXmlReader.cs
+++ b/src/MiniExcel.OpenXml/OpenXmlReader.cs
@@ -1,7 +1,4 @@
 using System.Collections.ObjectModel;
-using System.Xml.Linq;
-using MiniExcelLib.Core;
-using MiniExcelLib.OpenXml.Constants;
 using MiniExcelLib.OpenXml.Styles;
 using MiniExcelMapper = MiniExcelLib.Core.Reflection.MiniExcelMapper;
 using XmlReaderHelper = MiniExcelLib.OpenXml.Utils.XmlReaderHelper;

--- a/src/MiniExcel.OpenXml/Picture/OpenXmlPicture.cs
+++ b/src/MiniExcel.OpenXml/Picture/OpenXmlPicture.cs
@@ -1,5 +1,4 @@
 using System.Drawing;
-using MiniExcelLib.Core.Enums;
 
 namespace MiniExcelLib.OpenXml.Picture;
 

--- a/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
+++ b/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using MiniExcelLib.Core.Enums;
+using MiniExcelLib.OpenXml.Constants;
 
 namespace MiniExcelLib.OpenXml.Picture;
 
@@ -8,8 +9,8 @@ internal static partial class MiniExcelPictureImplement
     private static XmlNamespaceManager GetRNamespaceManager(XmlDocument doc)
     {
         var nsmgr = new XmlNamespaceManager(doc.NameTable);
-        nsmgr.AddNamespace("x", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
-        nsmgr.AddNamespace("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+        nsmgr.AddNamespace("x", Schemas.SpreadsheetmlXmlMain);
+        nsmgr.AddNamespace("r", Schemas.SpreadsheetmlXmlRelationships);
         return nsmgr;
     }
 
@@ -58,7 +59,7 @@ internal static partial class MiniExcelPictureImplement
                 var relsDoc = LoadXml(relsEntry);
                     
                 var namespaceManager = new XmlNamespaceManager(relsDoc.NameTable);
-                namespaceManager.AddNamespace("x", "http://schemas.openxmlformats.org/package/2006/relationships");
+                namespaceManager.AddNamespace("x", Schemas.OpenXmlPackageRelationships);
                     
                 var xpath = $"/x:Relationships/x:Relationship[@Id='{drawingRelId}']";
                 var relNode = relsDoc.SelectSingleNode(xpath, namespaceManager);
@@ -85,13 +86,13 @@ internal static partial class MiniExcelPictureImplement
                 var relsDoc = LoadXml(relsEntry);
                 var relNode = relsDoc.CreateElement("Relationship", relsDoc.DocumentElement.NamespaceURI);
                 relNode.SetAttribute("Id", drawingRelId);
-                relNode.SetAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing");
+                relNode.SetAttribute("Type", Schemas.SpreadsheetmlXmlDrawingRelationship);
                 relNode.SetAttribute("Target", $"../drawings/drawing{drawingId}.xml");
                 relsDoc.DocumentElement.AppendChild(relNode);
                 SaveXml(relsDoc, relsEntry);
                     
                 // Update [Content_Types].xml for drawing
-                var contentTypesEntry = archive.GetEntry("[Content_Types].xml");
+                var contentTypesEntry = archive.GetEntry(ExcelFileNames.ContentTypes);
                 var contentTypesDoc = LoadXml(contentTypesEntry);
                 var overrideDrawingFileExists = contentTypesDoc.DocumentElement
                     .ChildNodes
@@ -103,7 +104,7 @@ internal static partial class MiniExcelPictureImplement
                 {
                     var overrideNode = contentTypesDoc.CreateElement("Override", contentTypesDoc.DocumentElement.NamespaceURI);
                     overrideNode.SetAttribute("PartName", $"/xl/drawings/drawing{drawingId}.xml");
-                    overrideNode.SetAttribute("ContentType", "application/vnd.openxmlformats-officedocument.drawing+xml");
+                    overrideNode.SetAttribute("ContentType", ExcelContentTypes.Drawing);
                     contentTypesDoc.DocumentElement.AppendChild(overrideNode);
                 }
 
@@ -146,7 +147,7 @@ internal static partial class MiniExcelPictureImplement
 #endif
 
                 // Step 2: Update [Content_Types].xml for image
-                var contentTypesEntry = archive.GetEntry("[Content_Types].xml");
+                var contentTypesEntry = archive.GetEntry(ExcelFileNames.ContentTypes);
                 var contentTypesDoc = LoadXml(contentTypesEntry);
                 if (!contentTypesDoc.DocumentElement.InnerXml.Contains("image/png"))
                 {
@@ -164,7 +165,7 @@ internal static partial class MiniExcelPictureImplement
                 // Step 4: Add image relationship to drawing rels
                 var relNode = drawingRelsDoc.CreateElement("Relationship", drawingRelsDoc.DocumentElement.NamespaceURI);
                 relNode.SetAttribute("Id", relId);
-                relNode.SetAttribute("Type", "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image");
+                relNode.SetAttribute("Type", Schemas.SpreadsheetmlXmlImageRelationship);
                 relNode.SetAttribute("Target", $"../media/{imageName}");
                 drawingRelsDoc.DocumentElement.AppendChild(relNode);
             }
@@ -208,7 +209,7 @@ internal static partial class MiniExcelPictureImplement
     private static XmlNamespaceManager GetNamespaceManager(XmlDocument doc)
     {
         var nsmgr = new XmlNamespaceManager(doc.NameTable);
-        nsmgr.AddNamespace("x", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        nsmgr.AddNamespace("x", Schemas.SpreadsheetmlXmlMain);
         return nsmgr;
     }
 
@@ -219,8 +220,8 @@ internal static partial class MiniExcelPictureImplement
 
 	private static class DrawingXmlHelper
     {
-        private const string XdrNamespace = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing";
-        private const string ANamespace = "http://schemas.openxmlformats.org/drawingml/2006/main";
+        private const string XdrNamespace = Schemas.SpreadsheetmlXmlSpreadsheetDrawing;
+        private const string ANamespace = Schemas.SpreadsheetmlXmlDrawingml2006;
 
         private static long PixelsToEmu(int pixels) => pixels * 9525;
 
@@ -251,7 +252,7 @@ internal static partial class MiniExcelPictureImplement
 			var ns = new XmlNamespaceManager(doc.NameTable);
 			ns.AddNamespace("xdr", XdrNamespace);
 			ns.AddNamespace("a", ANamespace);
-			ns.AddNamespace("r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+			ns.AddNamespace("r", Schemas.SpreadsheetmlXmlRelationships);
 
 			// Root
 			XmlElement wsDr;
@@ -350,8 +351,8 @@ internal static partial class MiniExcelPictureImplement
 			var extNode = doc.CreateElement("a", "ext", ANamespace);
 			extNode.SetAttribute("uri", "{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}");
 
-			var creationId = doc.CreateElement("a16", "creationId", "http://schemas.microsoft.com/office/drawing/2014/main");
-			creationId.SetAttribute("id", "http://schemas.microsoft.com/office/drawing/2014/main", $"{{00000000-0008-0000-0000-0000{nextId:D6}000000}}");
+			var creationId = doc.CreateElement("a16", "creationId", Schemas.SpreadsheetmlXmlDrawing2014);
+			creationId.SetAttribute("id", Schemas.SpreadsheetmlXmlDrawing2014, $"{{00000000-0008-0000-0000-0000{nextId:D6}000000}}");
 
 			extNode.AppendChild(creationId);
 			extLst.AppendChild(extNode);
@@ -371,7 +372,7 @@ internal static partial class MiniExcelPictureImplement
 			var blipFill = doc.CreateElement("xdr", "blipFill", XdrNamespace);
 			var blip = doc.CreateElement("a", "blip", ANamespace);
 
-			blip.SetAttribute("xmlns:r", "http://schemas.openxmlformats.org/officeDocument/2006/relationships");
+			blip.SetAttribute("xmlns:r", Schemas.SpreadsheetmlXmlRelationships);
 			blip.SetAttribute("embed", ns.LookupNamespace("r"), relId);
 			blip.SetAttribute("cstate", "print");
 

--- a/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
+++ b/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
@@ -137,12 +137,11 @@ internal static partial class MiniExcelPictureImplement
                 var imagePath = $"xl/media/{imageName}";
                 var imageEntry = archive.CreateEntry(imagePath);
 
-#if NET
                 var entryStream = await imageEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
                 await using var disposableStream = entryStream.ConfigureAwait(false);
+#if NET
                 await entryStream.WriteAsync(imageBytes.AsMemory(), cancellationToken).ConfigureAwait(false);
 #else
-                using var entryStream = imageEntry.Open();
                 await entryStream.WriteAsync(imageBytes, 0, imageBytes.Length, cancellationToken).ConfigureAwait(false);
 #endif
 

--- a/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
+++ b/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
@@ -1,6 +1,4 @@
 ﻿using System.Drawing;
-using MiniExcelLib.Core.Enums;
-using MiniExcelLib.OpenXml.Constants;
 
 namespace MiniExcelLib.OpenXml.Picture;
 

--- a/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
+++ b/src/MiniExcel.OpenXml/Picture/OpenXmlPictureImplement.cs
@@ -136,7 +136,7 @@ internal static partial class MiniExcelPictureImplement
                 var imagePath = $"xl/media/{imageName}";
                 var imageEntry = archive.CreateEntry(imagePath);
 
-#if NET8_0_OR_GREATER
+#if NET
                 var entryStream = await imageEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
                 await using var disposableStream = entryStream.ConfigureAwait(false);
                 await entryStream.WriteAsync(imageBytes.AsMemory(), cancellationToken).ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
@@ -19,11 +19,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
         CellXfCount = 6
     };
 
-    private readonly SheetStyleBuilderContext _context = context;
     private readonly OpenXmlStyleOptions _styleOptions = styleOptions;
-
-    private XmlReader OldReader => _context.OldXmlReader!;
-    private XmlWriter NewWriter => _context.NewXmlWriter!;
 
     protected internal override SheetStyleElementInfos GetGeneratedElementInfos()
     {
@@ -35,7 +31,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
     {
         const int numFmtIndex = 166;
         var index = 0;
-        foreach (var map in _context.SheetStyleFormatsCache.FormatMappings)
+        foreach (var map in Context.SheetStyleFormatsCache.FormatMappings)
         {
             index++;
 
@@ -43,7 +39,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
              * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{x.Format}"
              */
             await NewWriter.WriteStartElementAsync(OldReader.Prefix, "numFmt", OldReader.NamespaceURI).ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + Context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "formatCode", null, map.Format).ConfigureAwait(false);
             await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
         }
@@ -275,9 +271,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyBorder", null, "0").ConfigureAwait(false);
@@ -296,9 +292,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "14").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 1}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 2}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount + 2}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1").ConfigureAwait(false);
@@ -317,9 +313,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1").ConfigureAwait(false);
@@ -382,9 +378,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount + 1}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount + 2}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount + 2}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "0").ConfigureAwait(false);
@@ -419,9 +415,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);
@@ -456,9 +452,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "14").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);
@@ -489,9 +485,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "0").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyBorder", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyAlignment", null, "1").ConfigureAwait(false);
@@ -508,9 +504,9 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
          */
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, "21").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
         await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);
@@ -535,7 +531,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
         await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
         
         const int numFmtIndex = 166;
-        for (var i = 1; i <= _context.CustomFormatCount; i++)
+        for (var i = 1; i <= Context.CustomFormatCount; i++)
         {
             /*
              * <x:xf numFmtId=""{numFmtIndex + i}"" fontId=""0"" fillId=""0"" borderId=""1"" xfId=""0"" applyNumberFormat=""1"" applyFill=""1"" applyBorder=""1"" applyAlignment=""1"" applyProtection=""1"">
@@ -544,10 +540,10 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context
              * </x:xf>
              */
             await NewWriter.WriteStartElementAsync(OldReader.Prefix, "xf", OldReader.NamespaceURI).ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + i + _context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{_context.OldElementInfos.FontCount}").ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{_context.OldElementInfos.FillCount}").ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{_context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + i + Context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "fontId", null, $"{Context.OldElementInfos.FontCount}").ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "fillId", null, $"{Context.OldElementInfos.FillCount}").ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "borderId", null, $"{Context.OldElementInfos.BorderCount + 1}").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "xfId", null, "0").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "applyNumberFormat", null, "1").ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "applyFill", null, "1").ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
@@ -3,7 +3,7 @@ using MiniExcelLib.Core.Enums;
 
 namespace MiniExcelLib.OpenXml.Styles.Builder;
 
-internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, OpenXmlStyleOptions styleOptions) : SheetStyleBuilderBase(context)
+internal partial class DefaultSheetStyleBuilder(SheetStyleBuilderContext context, OpenXmlStyleOptions styleOptions) : SheetStyleBuilderBase(context)
 {
     private const HorizontalCellAlignment DefaultHorizontalAlignment = HorizontalCellAlignment.Left;
     private const VerticalCellAlignment DefaultVerticalAlignment = VerticalCellAlignment.Bottom;
@@ -19,7 +19,7 @@ internal partial class DefaultSheetStyleBuilder(SheetStyleBuildContext context, 
         CellXfCount = 6
     };
 
-    private readonly SheetStyleBuildContext _context = context;
+    private readonly SheetStyleBuilderContext _context = context;
     private readonly OpenXmlStyleOptions _styleOptions = styleOptions;
 
     private XmlReader OldReader => _context.OldXmlReader!;

--- a/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/DefaultSheetStyleBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using MiniExcelLib.Core.Enums;
 
 namespace MiniExcelLib.OpenXml.Styles.Builder;
 

--- a/src/MiniExcel.OpenXml/Styles/Builder/MinimalSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/MinimalSheetStyleBuilder.cs
@@ -1,6 +1,6 @@
 ﻿namespace MiniExcelLib.OpenXml.Styles.Builder;
 
-internal partial class MinimalSheetStyleBuilder(SheetStyleBuildContext context) : SheetStyleBuilderBase(context)
+internal partial class MinimalSheetStyleBuilder(SheetStyleBuilderContext context) : SheetStyleBuilderBase(context)
 {
     private static readonly SheetStyleElementInfos GenerateElementInfos = new()
     {
@@ -12,7 +12,7 @@ internal partial class MinimalSheetStyleBuilder(SheetStyleBuildContext context) 
         CellXfCount = 6
     };
 
-    private readonly SheetStyleBuildContext _context = context;
+    private readonly SheetStyleBuilderContext _context = context;
 
     private XmlReader OldReader => _context.OldXmlReader!;
     private XmlWriter NewWriter => _context.NewXmlWriter!; 

--- a/src/MiniExcel.OpenXml/Styles/Builder/MinimalSheetStyleBuilder.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/MinimalSheetStyleBuilder.cs
@@ -11,11 +11,6 @@ internal partial class MinimalSheetStyleBuilder(SheetStyleBuilderContext context
         CellStyleXfCount = 1,
         CellXfCount = 6
     };
-
-    private readonly SheetStyleBuilderContext _context = context;
-
-    private XmlReader OldReader => _context.OldXmlReader!;
-    private XmlWriter NewWriter => _context.NewXmlWriter!; 
     
     protected internal override SheetStyleElementInfos GetGeneratedElementInfos()
     {
@@ -27,7 +22,7 @@ internal partial class MinimalSheetStyleBuilder(SheetStyleBuilderContext context
     {
         const int numFmtIndex = 166;
         var index = 0;
-        foreach (var map in _context.SheetStyleFormatsCache.FormatMappings)
+        foreach (var map in Context.SheetStyleFormatsCache.FormatMappings)
         {
             index++;
 
@@ -35,7 +30,7 @@ internal partial class MinimalSheetStyleBuilder(SheetStyleBuilderContext context
              * <x:numFmt numFmtId="{numFmtIndex + i}" formatCode="{item.Format}" />
              */
             await NewWriter.WriteStartElementAsync(OldReader.Prefix, "numFmt", OldReader.NamespaceURI).ConfigureAwait(false);
-            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + _context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
+            await NewWriter.WriteAttributeStringAsync(null, "numFmtId", null, (numFmtIndex + index + Context.OldElementInfos.NumFmtCount).ToString()).ConfigureAwait(false);
             await NewWriter.WriteAttributeStringAsync(null, "formatCode", null, map.Format).ConfigureAwait(false);
             await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
         }
@@ -125,7 +120,7 @@ internal partial class MinimalSheetStyleBuilder(SheetStyleBuilderContext context
         await NewWriter.WriteEndElementAsync().ConfigureAwait(false);
 
         const int numFmtIndex = 166;
-        for (var i = 1; i <= _context.CustomFormatCount; i++)
+        for (var i = 1; i <= Context.CustomFormatCount; i++)
         {
             /*
              * <x:xf numFmtId="{numFmtIndex + i}" applyNumberFormat="1"

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
@@ -2,7 +2,7 @@
 
 namespace MiniExcelLib.OpenXml.Styles.Builder;
 
-internal sealed partial class SheetStyleBuildContext(Dictionary<string, string> contentTypes, ZipArchive archive, Encoding encoding) : IDisposable, IAsyncDisposable
+internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string> contentTypes, ZipArchive archive, Encoding encoding) : IDisposable, IAsyncDisposable
 {
     private const string EmptyStylesXml = 
         """
@@ -137,7 +137,7 @@ internal sealed partial class SheetStyleBuildContext(Dictionary<string, string> 
         if (!_initialized)
             throw new InvalidOperationException("The context has not been initialized.");
         if (_disposed)
-            throw new ObjectDisposedException(nameof(SheetStyleBuildContext));
+            throw new ObjectDisposedException(nameof(SheetStyleBuilderContext));
         if (_finalized)
             throw new InvalidOperationException("The context has been finalized.");
 

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
@@ -1,6 +1,4 @@
-﻿using MiniExcelLib.OpenXml.Constants;
-
-namespace MiniExcelLib.OpenXml.Styles.Builder;
+﻿namespace MiniExcelLib.OpenXml.Styles.Builder;
 
 internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string> contentTypes, ZipArchive archive, Encoding encoding) : IDisposable, IAsyncDisposable
 {

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
@@ -49,7 +49,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
 
         if (styleEntry is not null)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var oldStyleXmlStream = await styleEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableStream = oldStyleXmlStream.ConfigureAwait(false);
 #else
@@ -88,7 +88,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
         var xmlReaderSettings = XmlReaderHelper.GetXmlReaderSettings(isAsync);
         if (_oldStyleXmlZipEntry is not null)
         {
-#if NET8_0_OR_GREATER
+#if NET
             var oldStyleXmlStream = await _oldStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using (_ = oldStyleXmlStream.ConfigureAwait(false))
 #else
@@ -99,7 +99,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
                 OldElementInfos = await ReadSheetStyleElementInfosAsync(reader, cancellationToken).ConfigureAwait(false);
             }
 
-#if NET8_0_OR_GREATER
+#if NET
             _oldXmlReaderStream = await _oldStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 #else
             _oldXmlReaderStream = _oldStyleXmlZipEntry.Open();
@@ -116,7 +116,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
             _newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
         }
 
-#if NET8_0_OR_GREATER
+#if NET
         _newXmlWriterStream = await _newStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 #else
         _newXmlWriterStream = _newStyleXmlZipEntry.Open();
@@ -145,7 +145,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
         {
             OldXmlReader?.Dispose();
             OldXmlReader = null;
-#if NET8_0_OR_GREATER
+#if NET
             if (_oldXmlReaderStream is not null)
             {
                 await _oldXmlReaderStream.DisposeAsync().ConfigureAwait(false);
@@ -159,7 +159,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
             _emptyStylesXmlStringReader = null;
 
             await NewXmlWriter!.FlushAsync().ConfigureAwait(false);
-#if NET8_0_OR_GREATER
+#if NET
             await NewXmlWriter.DisposeAsync().ConfigureAwait(false);
 #else
             NewXmlWriter.Dispose();
@@ -167,7 +167,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
 
             NewXmlWriter = null;
 
-#if NET8_0_OR_GREATER
+#if NET
             await _newXmlWriterStream!.DisposeAsync().ConfigureAwait(false);
 #else
             _newXmlWriterStream?.Dispose();
@@ -184,7 +184,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
                 _oldStyleXmlZipEntry = null;
                 var finalStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
 
-#if NET8_0_OR_GREATER
+#if NET
                 var tempStream = await _newStyleXmlZipEntry!.OpenAsync(cancellationToken).ConfigureAwait(false);
                 var newStream = await finalStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
                 await using (_ = tempStream.ConfigureAwait(false))

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
@@ -153,25 +153,16 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
 #else
             _oldXmlReaderStream?.Dispose();
 #endif
-            _oldXmlReaderStream = null;
-
-            _emptyStylesXmlStringReader?.Dispose();
-            _emptyStylesXmlStringReader = null;
 
             await NewXmlWriter!.FlushAsync().ConfigureAwait(false);
 #if NET
             await NewXmlWriter.DisposeAsync().ConfigureAwait(false);
-#else
-            NewXmlWriter.Dispose();
-#endif
-
-            NewXmlWriter = null;
-
-#if NET
             await _newXmlWriterStream!.DisposeAsync().ConfigureAwait(false);
 #else
+            NewXmlWriter.Dispose();
             _newXmlWriterStream?.Dispose();
 #endif
+            NewXmlWriter = null;
             _newXmlWriterStream = null;
 
             if (_oldStyleXmlZipEntry is null)

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuildContext.cs
@@ -49,13 +49,10 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
 
         if (styleEntry is not null)
         {
-#if NET
             var oldStyleXmlStream = await styleEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableStream = oldStyleXmlStream.ConfigureAwait(false);
-#else
-            using var oldStyleXmlStream = styleEntry.Open();
-#endif
             using var reader = XmlReader.Create(oldStyleXmlStream, XmlReaderHelper.GetXmlReaderSettings(isAsync));
+
             infos = await ReadSheetStyleElementInfosAsync(reader, cancellationToken).ConfigureAwait(false);
         }
         else
@@ -88,22 +85,14 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
         var xmlReaderSettings = XmlReaderHelper.GetXmlReaderSettings(isAsync);
         if (_oldStyleXmlZipEntry is not null)
         {
-#if NET
             var oldStyleXmlStream = await _oldStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using (_ = oldStyleXmlStream.ConfigureAwait(false))
-#else
-            using (var oldStyleXmlStream = _oldStyleXmlZipEntry.Open())
-#endif
             {
                 using var reader = XmlReader.Create(oldStyleXmlStream, xmlReaderSettings);
                 OldElementInfos = await ReadSheetStyleElementInfosAsync(reader, cancellationToken).ConfigureAwait(false);
             }
 
-#if NET
             _oldXmlReaderStream = await _oldStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-#else
-            _oldXmlReaderStream = _oldStyleXmlZipEntry.Open();
-#endif
             OldXmlReader = XmlReader.Create(_oldXmlReaderStream, xmlReaderSettings);
             _newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles + ".temp", CompressionLevel.Fastest);
         }
@@ -116,11 +105,7 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
             _newStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
         }
 
-#if NET
         _newXmlWriterStream = await _newStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-#else
-        _newXmlWriterStream = _newStyleXmlZipEntry.Open();
-#endif
         NewXmlWriter = XmlWriter.Create(_newXmlWriterStream, new XmlWriterSettings { Indent = true, Encoding = _encoding, Async = isAsync });
 
         _initialized = true;
@@ -145,23 +130,18 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
         {
             OldXmlReader?.Dispose();
             OldXmlReader = null;
-#if NET
             if (_oldXmlReaderStream is not null)
             {
                 await _oldXmlReaderStream.DisposeAsync().ConfigureAwait(false);
             }
-#else
-            _oldXmlReaderStream?.Dispose();
-#endif
 
             await NewXmlWriter!.FlushAsync().ConfigureAwait(false);
 #if NET
             await NewXmlWriter.DisposeAsync().ConfigureAwait(false);
-            await _newXmlWriterStream!.DisposeAsync().ConfigureAwait(false);
 #else
             NewXmlWriter.Dispose();
-            _newXmlWriterStream?.Dispose();
 #endif
+            await _newXmlWriterStream!.DisposeAsync().ConfigureAwait(false);
             NewXmlWriter = null;
             _newXmlWriterStream = null;
 
@@ -175,16 +155,12 @@ internal sealed partial class SheetStyleBuilderContext(Dictionary<string, string
                 _oldStyleXmlZipEntry = null;
                 var finalStyleXmlZipEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
 
-#if NET
                 var tempStream = await _newStyleXmlZipEntry!.OpenAsync(cancellationToken).ConfigureAwait(false);
-                var newStream = await finalStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-                await using (_ = tempStream.ConfigureAwait(false))
-                await using (_= newStream.ConfigureAwait(false))
-#else
-                using (var tempStream = _newStyleXmlZipEntry!.Open())
-                using (var newStream = finalStyleXmlZipEntry.Open())
-#endif
+                await using (var disposableTempStream = tempStream.ConfigureAwait(false))
                 {
+                    var newStream = await finalStyleXmlZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    await using var disposableNewStream = newStream.ConfigureAwait(false);
+
                     await tempStream.CopyToAsync(newStream, 4096, cancellationToken).ConfigureAwait(false);
                 }
 

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuilderBase.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuilderBase.cs
@@ -2,11 +2,11 @@
 
 internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext context) : ISheetStyleBuilder
 {
-    private readonly SheetStyleBuilderContext _context = context;
+    protected readonly SheetStyleBuilderContext Context = context;
     
     //todo: these may actually be null if used when the context is not initialized
-    private XmlReader OldReader => _context.OldXmlReader!;
-    private XmlWriter NewWriter => _context.NewXmlWriter!;
+    protected XmlReader OldReader => Context.OldXmlReader!;
+    protected XmlWriter NewWriter => Context.NewXmlWriter!;
 
     private static readonly Dictionary<string, int> AllElements = new()
     {
@@ -26,7 +26,7 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     [CreateSyncVersion]
     public virtual async Task BuildAsync(CancellationToken cancellationToken = default)
     {
-        await _context.InitializeAsync(GetGeneratedElementInfos(), cancellationToken).ConfigureAwait(false);
+        await Context.InitializeAsync(GetGeneratedElementInfos(), cancellationToken).ConfigureAwait(false);
         while (await OldReader.ReadAsync().ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -72,7 +72,7 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
             }
         }
 
-        await _context.FinalizeAndUpdateZipDictionaryAsync(cancellationToken).ConfigureAwait(false);
+        await Context.FinalizeAndUpdateZipDictionaryAsync(cancellationToken).ConfigureAwait(false);
     }
 
     protected internal abstract SheetStyleElementInfos GetGeneratedElementInfos();
@@ -106,12 +106,12 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
                     {
                         var value = element switch
                         {
-                            "numFmts" => (_context.OldElementInfos.NumFmtCount + _context.GeneratedElementInfos.NumFmtCount + _context.CustomFormatCount).ToString(),
-                            "fonts" => (_context.OldElementInfos.FontCount + _context.GeneratedElementInfos.FontCount).ToString(),
-                            "fills" => (_context.OldElementInfos.FillCount + _context.GeneratedElementInfos.FillCount).ToString(),
-                            "borders" => (_context.OldElementInfos.BorderCount + _context.GeneratedElementInfos.BorderCount).ToString(),
-                            "cellStyleXfs" => (_context.OldElementInfos.CellStyleXfCount + _context.GeneratedElementInfos.CellStyleXfCount).ToString(),
-                            "cellXfs" => (_context.OldElementInfos.CellXfCount + _context.GeneratedElementInfos.CellXfCount + _context.CustomFormatCount).ToString(),
+                            "numFmts" => (Context.OldElementInfos.NumFmtCount + Context.GeneratedElementInfos.NumFmtCount + Context.CustomFormatCount).ToString(),
+                            "fonts" => (Context.OldElementInfos.FontCount + Context.GeneratedElementInfos.FontCount).ToString(),
+                            "fills" => (Context.OldElementInfos.FillCount + Context.GeneratedElementInfos.FillCount).ToString(),
+                            "borders" => (Context.OldElementInfos.BorderCount + Context.GeneratedElementInfos.BorderCount).ToString(),
+                            "cellStyleXfs" => (Context.OldElementInfos.CellStyleXfCount + Context.GeneratedElementInfos.CellStyleXfCount).ToString(),
+                            "cellXfs" => (Context.OldElementInfos.CellXfCount + Context.GeneratedElementInfos.CellXfCount + Context.CustomFormatCount).ToString(),
                             _ => OldReader.Value
                         };
                         await NewWriter.WriteStringAsync(value).ConfigureAwait(false);
@@ -133,35 +133,35 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
         if (!AllElements.TryGetValue(OldReader.LocalName, out var elementIndex))
             return;
         
-        if (!_context.OldElementInfos.ExistsNumFmts && !_context.GeneratedElementInfos.ExistsNumFmts && AllElements["numFmts"] < elementIndex)
+        if (!Context.OldElementInfos.ExistsNumFmts && !Context.GeneratedElementInfos.ExistsNumFmts && AllElements["numFmts"] < elementIndex)
         {
             await GenerateNumFmtsAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsNumFmts = true;
+            Context.GeneratedElementInfos.ExistsNumFmts = true;
         }
-        else if (!_context.OldElementInfos.ExistsFonts && !_context.GeneratedElementInfos.ExistsFonts && AllElements["fonts"] < elementIndex)
+        else if (!Context.OldElementInfos.ExistsFonts && !Context.GeneratedElementInfos.ExistsFonts && AllElements["fonts"] < elementIndex)
         {
             await GenerateFontsAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsFonts = true;
+            Context.GeneratedElementInfos.ExistsFonts = true;
         }
-        else if (!_context.OldElementInfos.ExistsFills && !_context.GeneratedElementInfos.ExistsFills && AllElements["fills"] < elementIndex)
+        else if (!Context.OldElementInfos.ExistsFills && !Context.GeneratedElementInfos.ExistsFills && AllElements["fills"] < elementIndex)
         {
             await GenerateFillsAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsFills = true;
+            Context.GeneratedElementInfos.ExistsFills = true;
         }
-        else if (!_context.OldElementInfos.ExistsBorders && !_context.GeneratedElementInfos.ExistsBorders && AllElements["borders"] < elementIndex)
+        else if (!Context.OldElementInfos.ExistsBorders && !Context.GeneratedElementInfos.ExistsBorders && AllElements["borders"] < elementIndex)
         {
             await GenerateBordersAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsBorders = true;
+            Context.GeneratedElementInfos.ExistsBorders = true;
         }
-        else if (!_context.OldElementInfos.ExistsCellStyleXfs && !_context.GeneratedElementInfos.ExistsCellStyleXfs && AllElements["cellStyleXfs"] < elementIndex)
+        else if (!Context.OldElementInfos.ExistsCellStyleXfs && !Context.GeneratedElementInfos.ExistsCellStyleXfs && AllElements["cellStyleXfs"] < elementIndex)
         {
             await GenerateCellStyleXfsAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsCellStyleXfs = true;
+            Context.GeneratedElementInfos.ExistsCellStyleXfs = true;
         }
-        else if (!_context.OldElementInfos.ExistsCellXfs && !_context.GeneratedElementInfos.ExistsCellXfs && AllElements["cellXfs"] < elementIndex)
+        else if (!Context.OldElementInfos.ExistsCellXfs && !Context.GeneratedElementInfos.ExistsCellXfs && AllElements["cellXfs"] < elementIndex)
         {
             await GenerateCellXfsAsync().ConfigureAwait(false);
-            _context.GeneratedElementInfos.ExistsCellXfs = true;
+            Context.GeneratedElementInfos.ExistsCellXfs = true;
         }
     }
 
@@ -170,7 +170,7 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     {
         switch (OldReader.LocalName)
         {
-            case "styleSheet" when !_context.OldElementInfos.ExistsNumFmts && !_context.GeneratedElementInfos.ExistsNumFmts:
+            case "styleSheet" when !Context.OldElementInfos.ExistsNumFmts && !Context.GeneratedElementInfos.ExistsNumFmts:
                 await GenerateNumFmtsAsync().ConfigureAwait(false);
                 break;
             case "numFmts":
@@ -198,11 +198,11 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateNumFmtsAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "numFmts", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.NumFmtCount + _context.GeneratedElementInfos.NumFmtCount + _context.CustomFormatCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.NumFmtCount + Context.GeneratedElementInfos.NumFmtCount + Context.CustomFormatCount).ToString()).ConfigureAwait(false);
         await GenerateNumFmtAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
 
-        if (!_context.OldElementInfos.ExistsFonts)
+        if (!Context.OldElementInfos.ExistsFonts)
         {
             await GenerateFontsAsync().ConfigureAwait(false);
         }
@@ -215,11 +215,11 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateFontsAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "fonts", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.FontCount + _context.GeneratedElementInfos.FontCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.FontCount + Context.GeneratedElementInfos.FontCount).ToString()).ConfigureAwait(false);
         await GenerateFontAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
 
-        if (!_context.OldElementInfos.ExistsFills)
+        if (!Context.OldElementInfos.ExistsFills)
         {
             await GenerateFillsAsync().ConfigureAwait(false);
         }
@@ -232,11 +232,11 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateFillsAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "fills", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.FillCount + _context.GeneratedElementInfos.FillCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.FillCount + Context.GeneratedElementInfos.FillCount).ToString()).ConfigureAwait(false);
         await GenerateFillAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
 
-        if (!_context.OldElementInfos.ExistsBorders)
+        if (!Context.OldElementInfos.ExistsBorders)
         {
             await GenerateBordersAsync().ConfigureAwait(false);
         }
@@ -249,11 +249,11 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateBordersAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "borders", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.BorderCount + _context.GeneratedElementInfos.BorderCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.BorderCount + Context.GeneratedElementInfos.BorderCount).ToString()).ConfigureAwait(false);
         await GenerateBorderAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
 
-        if (!_context.OldElementInfos.ExistsCellStyleXfs)
+        if (!Context.OldElementInfos.ExistsCellStyleXfs)
         {
             await GenerateCellStyleXfsAsync().ConfigureAwait(false);
         }
@@ -266,11 +266,11 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateCellStyleXfsAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "cellStyleXfs", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.CellStyleXfCount + _context.GeneratedElementInfos.CellStyleXfCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.CellStyleXfCount + Context.GeneratedElementInfos.CellStyleXfCount).ToString()).ConfigureAwait(false);
         await GenerateCellStyleXfAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
 
-        if (!_context.OldElementInfos.ExistsCellXfs)
+        if (!Context.OldElementInfos.ExistsCellXfs)
         {
             await GenerateCellXfsAsync().ConfigureAwait(false);
         }
@@ -283,7 +283,7 @@ internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext c
     protected virtual async Task GenerateCellXfsAsync()
     {
         await NewWriter.WriteStartElementAsync(OldReader.Prefix, "cellXfs", OldReader.NamespaceURI).ConfigureAwait(false);
-        await NewWriter.WriteAttributeStringAsync(null, "count", null, (_context.OldElementInfos.CellXfCount + _context.GeneratedElementInfos.CellXfCount + _context.CustomFormatCount).ToString()).ConfigureAwait(false);
+        await NewWriter.WriteAttributeStringAsync(null, "count", null, (Context.OldElementInfos.CellXfCount + Context.GeneratedElementInfos.CellXfCount + Context.CustomFormatCount).ToString()).ConfigureAwait(false);
         await GenerateCellXfAsync().ConfigureAwait(false);
         await NewWriter.WriteFullEndElementAsync().ConfigureAwait(false);
     }

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuilderBase.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleBuilderBase.cs
@@ -1,8 +1,8 @@
 ﻿namespace MiniExcelLib.OpenXml.Styles.Builder;
 
-internal abstract partial class SheetStyleBuilderBase(SheetStyleBuildContext context) : ISheetStyleBuilder
+internal abstract partial class SheetStyleBuilderBase(SheetStyleBuilderContext context) : ISheetStyleBuilder
 {
-    private readonly SheetStyleBuildContext _context = context;
+    private readonly SheetStyleBuilderContext _context = context;
     
     //todo: these may actually be null if used when the context is not initialized
     private XmlReader OldReader => _context.OldXmlReader!;

--- a/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleFormatsCache.cs
+++ b/src/MiniExcel.OpenXml/Styles/Builder/SheetStyleFormatsCache.cs
@@ -1,5 +1,6 @@
 namespace MiniExcelLib.OpenXml.Styles.Builder;
 
+// todo: find a way to make it compatible with SharedStringsDiskCache
 internal class SheetStyleFormatsCache
 {
     private readonly Dictionary<string, int> _formatMappings = [];

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlHeaderStyle.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlHeaderStyle.cs
@@ -1,5 +1,4 @@
 using System.Drawing;
-using MiniExcelLib.Core.Enums;
 
 namespace MiniExcelLib.OpenXml.Styles;
 

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlStyleOptions.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlStyleOptions.cs
@@ -1,7 +1,5 @@
 namespace MiniExcelLib.OpenXml.Styles;
 
-using MiniExcelLib.Core.Enums;
-
 public class OpenXmlStyleOptions
 {
     public bool WrapCellContents { get; set; }

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
@@ -13,7 +13,7 @@ internal class OpenXmlStyles
 
     public OpenXmlStyles(OpenXmlZip zip)
     {
-        using var reader = zip.GetXmlReader("xl/styles.xml");
+        using var reader = zip.GetXmlReader(ExcelFileNames.Styles);
         if (reader is null)
             throw new InvalidDataException("The OpenXml styles could not be found, the file might be malformed.");
                 

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
@@ -1,4 +1,3 @@
-using MiniExcelLib.OpenXml.Constants;
 using XmlReaderHelper = MiniExcelLib.OpenXml.Utils.XmlReaderHelper;
 
 namespace MiniExcelLib.OpenXml.Styles;

--- a/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
+++ b/src/MiniExcel.OpenXml/Styles/OpenXmlStyles.cs
@@ -86,12 +86,7 @@ internal class OpenXmlStyles
                             type = typeof(DateTime?);
                         }
 
-#if NETCOREAPP2_0_OR_GREATER
                         _customFormats.TryAdd(numFmtId, new NumberFormatString(formatCode, type));
-#else
-                        if (!_customFormats.ContainsKey(numFmtId))
-                            _customFormats.Add(numFmtId, new NumberFormatString(formatCode, type));
-#endif
                         reader.Skip();
                     }
                     else if (!reader.SkipContent())

--- a/src/MiniExcel.OpenXml/Styles/SheetStyleElementInfos.cs
+++ b/src/MiniExcel.OpenXml/Styles/SheetStyleElementInfos.cs
@@ -1,6 +1,6 @@
 ﻿namespace MiniExcelLib.OpenXml.Styles;
 
-public class SheetStyleElementInfos
+internal class SheetStyleElementInfos
 {
     public bool ExistsNumFmts { get; set; }
     public int NumFmtCount { get; set; }

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -44,11 +44,10 @@ internal partial class OpenXmlTemplate
     [CreateSyncVersion]
     private async Task GenerateSheetByUpdateModeAsync(ZipArchiveEntry sheetZipEntry, Stream stream, Stream sheetStream, IDictionary<string, object> inputMaps, IDictionary<int, string> sharedStrings, bool mergeCells = false, CancellationToken cancellationToken = default)
     {
-#if NET
         var doc = await XDocument.LoadAsync(sheetStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+#if NET
         await sheetStream.DisposeAsync().ConfigureAwait(false);
 #else
-        var doc = XDocument.Load(sheetStream);
         sheetStream.Dispose();
 #endif
 
@@ -80,11 +79,11 @@ internal partial class OpenXmlTemplate
 #if NET
         var newTemplateStream = await templateSheetZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableNewTemplateStream = newTemplateStream.ConfigureAwait(false);
-        var doc = await XDocument.LoadAsync(newTemplateStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 #else
         using var newTemplateStream = templateSheetZipEntry.Open();
-        var doc = XDocument.Load(newTemplateStream);
 #endif
+        var doc = await XDocument.LoadAsync(newTemplateStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
+
         var worksheet = doc.Element(SpreadsheetNs + "worksheet");
         var prefix = worksheet?.GetPrefixOfNamespace(SpreadsheetNs);
         if (!string.IsNullOrEmpty(prefix))

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -28,7 +28,7 @@ internal partial class OpenXmlTemplate
     [GeneratedRegex(@"<(?:x:)?v>\s*</(?:x:)?v>")] private static partial Regex EmptyVTagRegexImpl();
     private static readonly Regex EmptyVTagRegex = EmptyVTagRegexImpl();
 #else
-    private static readonly Regex IsExpressionRegex = new("(?<={{).*?(?=}})");
+    private static readonly Regex IsExpressionRegex = new("(?<={{).*?(?=}})", RegexOptions.Compiled);
     private static readonly Regex CellRegex = new("([A-Z]+)([0-9]+)", RegexOptions.Compiled);
     private static readonly Regex TemplateRegex = new(@"\{\{(.*?)\}\}", RegexOptions.Compiled);
     private static readonly Regex NonTemplateRegex = new(@".*?\{\{.*?\}\}.*?", RegexOptions.Compiled);

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -15,17 +15,8 @@ internal partial class OpenXmlTemplate
         Async = true
 #endif
     };
-    
-    private static readonly XmlWriterSettings FragXmlWriterSettings = new()
-    {
-        OmitXmlDeclaration = true,
-        ConformanceLevel =  ConformanceLevel.Fragment,
-#if !SYNC_ONLY
-        Async = true
-#endif
-    };
 
-#if NET8_0_OR_GREATER
+#if NET
     [GeneratedRegex("(?<={{).*?(?=}})")] private static partial Regex ExpressionRegex();
     private static readonly Regex IsExpressionRegex = ExpressionRegex();
     [GeneratedRegex("([A-Z]+)([0-9]+)")] private static partial Regex CellRegexImpl();
@@ -53,7 +44,7 @@ internal partial class OpenXmlTemplate
     [CreateSyncVersion]
     private async Task GenerateSheetByUpdateModeAsync(ZipArchiveEntry sheetZipEntry, Stream stream, Stream sheetStream, IDictionary<string, object> inputMaps, IDictionary<int, string> sharedStrings, bool mergeCells = false, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var doc = await XDocument.LoadAsync(sheetStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
         await sheetStream.DisposeAsync().ConfigureAwait(false);
 #else
@@ -73,7 +64,7 @@ internal partial class OpenXmlTemplate
         GetMergeCells(worksheet);
         UpdateDimensionAndGetRowsInfo(inputMaps, worksheet, rows, !mergeCells);
 
-#if NET8_0_OR_GREATER
+#if NET
         var writer = XmlWriter.Create(stream, DocXmlWriterSettings);
         await using var disposableWriter = writer.ConfigureAwait(false);
 #else
@@ -86,7 +77,7 @@ internal partial class OpenXmlTemplate
     [CreateSyncVersion]
     private async Task GenerateSheetByCreateModeAsync(ZipArchiveEntry templateSheetZipEntry, Stream outputZipSheetEntryStream, IDictionary<string, object?> inputMaps, IDictionary<int, string> sharedStrings, bool mergeCells = false, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var newTemplateStream = await templateSheetZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableNewTemplateStream = newTemplateStream.ConfigureAwait(false);
         var doc = await XDocument.LoadAsync(newTemplateStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
@@ -111,7 +102,7 @@ internal partial class OpenXmlTemplate
         GetMergeCells(worksheet);
         UpdateDimensionAndGetRowsInfo(inputMaps, worksheet, rows, !mergeCells);
 
-#if NET8_0_OR_GREATER
+#if NET
         var writer = XmlWriter.Create(outputZipSheetEntryStream, DocXmlWriterSettings);
         await using var disposableWriter = writer.ConfigureAwait(false);
 #else
@@ -236,7 +227,7 @@ internal partial class OpenXmlTemplate
 
         foreach (var beforeElement in beforeSheetData)
         {
-#if NET8_0_OR_GREATER
+#if NET
             await beforeElement.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
 #else
             beforeElement.WriteTo(writer);
@@ -493,7 +484,7 @@ internal partial class OpenXmlTemplate
 
         foreach (var afterElement in afterSheetData)
         {
-#if NET8_0_OR_GREATER
+#if NET
             await afterElement.WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
 #else
             afterElement.WriteTo(writer);
@@ -633,11 +624,8 @@ internal partial class OpenXmlTemplate
             else
             {
                 var replacements = new Dictionary<string, string>();
-#if NET8_0_OR_GREATER
                 string MatchDelegate(Match x) => replacements.GetValueOrDefault(x.Groups[1].Value, "");
-#else
-                string MatchDelegate(Match x) => replacements.TryGetValue(x.Groups[1].Value, out var repl) ? repl : "";
-#endif
+
                 foreach (var prop in rowInfo.PropsMap)
                 {
                     var propInfo = prop.Value.PropertyInfo;

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -45,11 +45,7 @@ internal partial class OpenXmlTemplate
     private async Task GenerateSheetByUpdateModeAsync(ZipArchiveEntry sheetZipEntry, Stream stream, Stream sheetStream, IDictionary<string, object> inputMaps, IDictionary<int, string> sharedStrings, bool mergeCells = false, CancellationToken cancellationToken = default)
     {
         var doc = await XDocument.LoadAsync(sheetStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
-#if NET
         await sheetStream.DisposeAsync().ConfigureAwait(false);
-#else
-        sheetStream.Dispose();
-#endif
 
         // we can't update ZipArchiveEntry directly, so we delete the original entry and recreate it
         sheetZipEntry.Delete();
@@ -76,12 +72,8 @@ internal partial class OpenXmlTemplate
     [CreateSyncVersion]
     private async Task GenerateSheetByCreateModeAsync(ZipArchiveEntry templateSheetZipEntry, Stream outputZipSheetEntryStream, IDictionary<string, object?> inputMaps, IDictionary<int, string> sharedStrings, bool mergeCells = false, CancellationToken cancellationToken = default)
     {
-#if NET
         var newTemplateStream = await templateSheetZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableNewTemplateStream = newTemplateStream.ConfigureAwait(false);
-#else
-        using var newTemplateStream = templateSheetZipEntry.Open();
-#endif
         var doc = await XDocument.LoadAsync(newTemplateStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
         var worksheet = doc.Element(SpreadsheetNs + "worksheet");

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.Impl.cs
@@ -1,8 +1,3 @@
-using MiniExcelLib.Core.Attributes;
-using System.ComponentModel;
-using System.Xml.Linq;
-using  MiniExcelLib.OpenXml.Constants;
-
 namespace MiniExcelLib.OpenXml.Templates;
 
 internal partial class OpenXmlTemplate

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
@@ -30,7 +30,7 @@ internal partial class OpenXmlTemplate
     private async Task MergeSameCellsImplAsync(Stream stream, CancellationToken cancellationToken = default)
     {
         await stream.CopyToAsync(_outputFileStream
-#if NET8_0_OR_GREATER
+#if NET
             , cancellationToken
 #endif
         ).ConfigureAwait(false);
@@ -58,7 +58,7 @@ internal partial class OpenXmlTemplate
 
             var entry = archive.ZipFile.CreateEntry(sheet.FullName);
 
-#if NET8_0_OR_GREATER
+#if NET
             var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
@@ -7,24 +7,18 @@ internal partial class OpenXmlTemplate
     [CreateSyncVersion]
     public async Task MergeSameCellsAsync(string path, CancellationToken cancellationToken = default)
     {
-#if NETSTANDARD2_0
-        using var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-#else
         var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         await using var disposableStream = stream.ConfigureAwait(false);
-#endif
+
         await MergeSameCellsImplAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
     [CreateSyncVersion]
     public async Task MergeSameCellsAsync(byte[] fileInBytes, CancellationToken cancellationToken = default)
     {
-#if NETSTANDARD2_0
-        using var stream = new MemoryStream(fileInBytes);
-#else
         var stream = new MemoryStream(fileInBytes);
         await using var disposableStream = stream.ConfigureAwait(false);
-#endif
+
         await MergeSameCellsImplAsync(stream, cancellationToken).ConfigureAwait(false);
     }
 
@@ -59,16 +53,11 @@ internal partial class OpenXmlTemplate
 
             var entry = archive.ZipFile.CreateEntry(sheet.FullName);
 
-#if NET
             var sheetStream = await sheet.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetStream = sheetStream.ConfigureAwait(false);
 
             var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
-#else
-            using var sheetStream = sheet.Open();
-            using var zipStream = entry.Open();
-#endif
 
             await GenerateSheetByUpdateModeAsync(sheet, zipStream, sheetStream, new Dictionary<string, object>(), sharedStrings, mergeCells: true, cancellationToken).ConfigureAwait(false);
         }

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.OpenXml.Constants;
-
 namespace MiniExcelLib.OpenXml.Templates;
 
 internal partial class OpenXmlTemplate

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.MergeCells.cs
@@ -1,3 +1,5 @@
+using MiniExcelLib.OpenXml.Constants;
+
 namespace MiniExcelLib.OpenXml.Templates;
 
 internal partial class OpenXmlTemplate
@@ -44,8 +46,7 @@ internal partial class OpenXmlTemplate
 
         //read all xlsx sheets
         var sheets = archive.ZipFile.Entries.Where(w =>
-            w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
-            w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase)
+            w.FullName.TrimStart('/').StartsWith(ExcelFileNames.WorksheetBase, StringComparison.OrdinalIgnoreCase)
         ).ToList();
 
         foreach (var sheet in sheets)

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
@@ -1,4 +1,5 @@
 using MiniExcelLib.Core;
+using MiniExcelLib.OpenXml.Constants;
 using CalcChainHelper = MiniExcelLib.OpenXml.Utils.CalcChainHelper;
 
 namespace MiniExcelLib.OpenXml.Templates;
@@ -80,9 +81,12 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
         foreach (var entry in originalArchive.Entries)
         {
             var entryName = entry.FullName.TrimStart('/');
-            if (entryName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) || entryName.Equals("xl/calcChain.xml"))
+            if (entryName.StartsWith(ExcelFileNames.WorksheetBase, StringComparison.OrdinalIgnoreCase) || 
+                entryName.Equals(ExcelFileNames.CalcChain, StringComparison.OrdinalIgnoreCase))
+            {
                 continue;
-                    
+            }
+
             // Create a new entry in the new archive with the same name
             var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 
@@ -113,7 +117,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
         var templateSheets = templateReader.Archive.ZipFile.Entries
             .Where(entry => entry.FullName
                 .TrimStart('/')
-                .StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase));
+                .StartsWith(ExcelFileNames.WorksheetBase, StringComparison.OrdinalIgnoreCase));
 
         int sheetIdx = 0;
         foreach (var templateSheet in templateSheets)
@@ -134,6 +138,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
 #else
             using var outputZipSheetEntryStream = outputZipEntry.Open();
 #endif
+
             await GenerateSheetByCreateModeAsync(templateSheet, outputZipSheetEntryStream, inputValues, templateSharedStrings, cancellationToken: cancellationToken).ConfigureAwait(false);
             
             //doc.Save(zipStream); //don't do it because: https://user-images.githubusercontent.com/12729184/114361127-61a5d100-9ba8-11eb-9bb9-34f076ee28a2.png
@@ -144,14 +149,13 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
         }
 
         // create mode we need to not create first then create here
-        var calcChain = outputFileArchive.EntryCollection.FirstOrDefault(e => e.FullName.Contains("xl/calcChain.xml"));
+        var calcChain = outputFileArchive.EntryCollection.FirstOrDefault(e 
+            => e.FullName.TrimStart('/').Equals(ExcelFileNames.CalcChain, StringComparison.OrdinalIgnoreCase));
+
         if (calcChain is not null)
         {
-            var calcChainPathName = calcChain.FullName;
-            //calcChain.Delete();
-
-            var calcChainEntry = outputFileArchive.ZipFile.CreateEntry(calcChainPathName);
 #if NET
+            var calcChainEntry = outputFileArchive.ZipFile.CreateEntry(calcChain.FullName);
             var calcChainStream = await calcChainEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableChainEntryStream = calcChainStream.ConfigureAwait(false);
 #else
@@ -163,7 +167,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
         {
             foreach (var entry in originalArchive.Entries)
             {
-                if (entry.FullName.Contains("xl/calcChain.xml"))
+                if (entry.FullName.TrimStart('/').Equals(ExcelFileNames.CalcChain, StringComparison.OrdinalIgnoreCase))
                 {
                     var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
@@ -21,24 +21,18 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
     [CreateSyncVersion]
     public async Task SaveAsByTemplateAsync(string templatePath, object value, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = File.Open(templatePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = File.Open(templatePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-#endif
+
         await SaveAsByTemplateAsync(stream, value, cancellationToken).ConfigureAwait(false);
     }
 
     [CreateSyncVersion]
     public async Task SaveAsByTemplateAsync(byte[] templateBytes, object value, CancellationToken cancellationToken = default)
     {
-#if NET
         var stream = new MemoryStream(templateBytes);
         await using var disposableStream = stream.ConfigureAwait(false); 
-#else
-        using var stream = new MemoryStream(templateBytes);
-#endif
+
         await SaveAsByTemplateAsync(stream, value, cancellationToken).ConfigureAwait(false);
     }
 
@@ -91,16 +85,11 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
             var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 
             // Copy the content of the original entry to the new entry
-#if NET
             var originalEntryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableEntryStream = originalEntryStream.ConfigureAwait(false);
 
             var newEntryStream = await newEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableNewEntryStream = newEntryStream.ConfigureAwait(false);
-#else
-            using var originalEntryStream = entry.Open();
-            using var newEntryStream = newEntry.Open();
-#endif
 
             await originalEntryStream.CopyToAsync(newEntryStream
 #if NET
@@ -132,12 +121,8 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
             var inputValues = _inputValueExtractor.ToValueDictionary(value);
             var outputZipEntry = outputFileArchive.ZipFile.CreateEntry(templateFullName);
 
-#if NET
             var outputZipSheetEntryStream = await outputZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetEntryStream = outputZipSheetEntryStream.ConfigureAwait(false);
-#else
-            using var outputZipSheetEntryStream = outputZipEntry.Open();
-#endif
 
             await GenerateSheetByCreateModeAsync(templateSheet, outputZipSheetEntryStream, inputValues, templateSharedStrings, cancellationToken: cancellationToken).ConfigureAwait(false);
             
@@ -154,13 +139,10 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
 
         if (calcChain is not null)
         {
-#if NET
             var calcChainEntry = outputFileArchive.ZipFile.CreateEntry(calcChain.FullName);
             var calcChainStream = await calcChainEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableChainEntryStream = calcChainStream.ConfigureAwait(false);
-#else
-            using var calcChainStream = calcChainEntry.Open();
-#endif
+
             await CalcChainHelper.GenerateCalcChainSheetAsync(calcChainStream, _calcChainContent.ToString(), cancellationToken).ConfigureAwait(false);
         }
         else
@@ -172,16 +154,11 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
                     var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 
                     // Copy the content of the original entry to the new entry
-#if NET
                     var originalEntryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
                     await using var disposableEntryStream = originalEntryStream.ConfigureAwait(false);
 
                     var newEntryStream = await newEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
                     await using var disposableNewEntryStream = newEntryStream.ConfigureAwait(false);
-#else
-                    using var originalEntryStream = entry.Open();
-                    using var newEntryStream = newEntry.Open();
-#endif
 
                     await originalEntryStream.CopyToAsync(newEntryStream
 #if NET

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
@@ -20,7 +20,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
     [CreateSyncVersion]
     public async Task SaveAsByTemplateAsync(string templatePath, object value, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = File.Open(templatePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -32,7 +32,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
     [CreateSyncVersion]
     public async Task SaveAsByTemplateAsync(byte[] templateBytes, object value, CancellationToken cancellationToken = default)
     {
-#if NET8_0_OR_GREATER
+#if NET
         var stream = new MemoryStream(templateBytes);
         await using var disposableStream = stream.ConfigureAwait(false); 
 #else
@@ -87,7 +87,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
             var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 
             // Copy the content of the original entry to the new entry
-#if NET8_0_OR_GREATER
+#if NET
             var originalEntryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableEntryStream = originalEntryStream.ConfigureAwait(false);
 
@@ -99,7 +99,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
 #endif
 
             await originalEntryStream.CopyToAsync(newEntryStream
-#if NET8_0_OR_GREATER
+#if NET
                 , cancellationToken
 #endif
             ).ConfigureAwait(false);
@@ -128,7 +128,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
             var inputValues = _inputValueExtractor.ToValueDictionary(value);
             var outputZipEntry = outputFileArchive.ZipFile.CreateEntry(templateFullName);
 
-#if NET8_0_OR_GREATER
+#if NET
             var outputZipSheetEntryStream = await outputZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableSheetEntryStream = outputZipSheetEntryStream.ConfigureAwait(false);
 #else
@@ -151,7 +151,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
             //calcChain.Delete();
 
             var calcChainEntry = outputFileArchive.ZipFile.CreateEntry(calcChainPathName);
-#if NET8_0_OR_GREATER
+#if NET
             var calcChainStream = await calcChainEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableChainEntryStream = calcChainStream.ConfigureAwait(false);
 #else
@@ -168,7 +168,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
                     var newEntry = outputFileArchive.ZipFile.CreateEntry(entry.FullName);
 
                     // Copy the content of the original entry to the new entry
-#if NET8_0_OR_GREATER
+#if NET
                     var originalEntryStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
                     await using var disposableEntryStream = originalEntryStream.ConfigureAwait(false);
 
@@ -180,7 +180,7 @@ internal partial class OpenXmlTemplate : IMiniExcelTemplate
 #endif
 
                     await originalEntryStream.CopyToAsync(newEntryStream
-#if NET8_0_OR_GREATER
+#if NET
                         , cancellationToken
 #endif
                     ).ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplate.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.Core;
-using MiniExcelLib.OpenXml.Constants;
 using CalcChainHelper = MiniExcelLib.OpenXml.Utils.CalcChainHelper;
 
 namespace MiniExcelLib.OpenXml.Templates;

--- a/src/MiniExcel.OpenXml/Templates/OpenXmlTemplateUtils.cs
+++ b/src/MiniExcel.OpenXml/Templates/OpenXmlTemplateUtils.cs
@@ -1,6 +1,4 @@
-﻿using System.Xml.Linq;
-
-namespace MiniExcelLib.OpenXml.Templates;
+﻿namespace MiniExcelLib.OpenXml.Templates;
 
 internal class XRowInfo
 {

--- a/src/MiniExcel.OpenXml/Utils/CalcChainHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/CalcChainHelper.cs
@@ -24,7 +24,7 @@ internal static partial class CalcChainHelper
 	{
 		var content = $"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><calcChain xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">{calcChainContent}</calcChain>";
 
-#if NET8_0_OR_GREATER
+#if NET
 		var writer = new StreamWriter(calcChainStream, Encoding.UTF8);
 		await using var disposableWriter = writer.ConfigureAwait(false);
 		await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Utils/CalcChainHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/CalcChainHelper.cs
@@ -28,9 +28,9 @@ internal static partial class CalcChainHelper
 		var writer = new StreamWriter(calcChainStream, Encoding.UTF8);
 		await using var disposableWriter = writer.ConfigureAwait(false);
 		await writer.WriteAsync(content.AsMemory(), cancellationToken).ConfigureAwait(false);
-	#else
+#else
 		using var writer = new StreamWriter(calcChainStream, Encoding.UTF8);
 		await writer.WriteAsync(content).ConfigureAwait(false);
-	#endif
+#endif
 	}
 }

--- a/src/MiniExcel.OpenXml/Utils/MiniExcelPropertyHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/MiniExcelPropertyHelper.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.Core;
-
 namespace MiniExcelLib.OpenXml.Utils;
 
 internal static class MiniExcelPropertyHelper

--- a/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
@@ -127,7 +127,7 @@ internal static partial class XmlReaderHelper
             {
                 result.Append(await reader.ReadElementContentAsStringAsync()
 #if NET
-                        .WaitAsync(cancellationToken)
+                    .WaitAsync(cancellationToken)
 #endif
                     .ConfigureAwait(false));
             }

--- a/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
@@ -13,7 +13,7 @@ internal static partial class XmlReaderHelper
         if (reader.IsEmptyElement)
         {
             await reader.ReadAsync()
-#if NET6_0_OR_GREATER
+#if NET
                 .WaitAsync(cancellationToken)
 #endif
                 .ConfigureAwait(false);
@@ -21,13 +21,13 @@ internal static partial class XmlReaderHelper
         }
 
         await reader.MoveToContentAsync()
-#if NET6_0_OR_GREATER
+#if NET
             .WaitAsync(cancellationToken)
 #endif
             .ConfigureAwait(false);
 
         await reader.ReadAsync()
-#if NET6_0_OR_GREATER
+#if NET
             .WaitAsync(cancellationToken)
 #endif
             .ConfigureAwait(false);
@@ -41,7 +41,7 @@ internal static partial class XmlReaderHelper
         if (reader.NodeType == XmlNodeType.EndElement)
         {
             await reader.ReadAsync()
-#if NET6_0_OR_GREATER
+#if NET
                 .WaitAsync(cancellationToken)
 #endif
                 .ConfigureAwait(false);
@@ -49,7 +49,7 @@ internal static partial class XmlReaderHelper
         }
 
         await reader.SkipAsync()
-#if NET6_0_OR_GREATER
+#if NET
             .WaitAsync(cancellationToken)
 #endif
             .ConfigureAwait(false);
@@ -95,7 +95,7 @@ internal static partial class XmlReaderHelper
             {
                 // There are multiple <t> in a <si>. Concatenate <t> within an <si>.
                 result.Append(await reader.ReadElementContentAsStringAsync()
-#if NET6_0_OR_GREATER
+#if NET
                     .WaitAsync(cancellationToken)
 #endif
                     .ConfigureAwait(false));
@@ -126,7 +126,7 @@ internal static partial class XmlReaderHelper
             if (reader.IsStartElement("t", Ns))
             {
                 result.Append(await reader.ReadElementContentAsStringAsync()
-#if NET6_0_OR_GREATER
+#if NET
                         .WaitAsync(cancellationToken)
 #endif
                     .ConfigureAwait(false));

--- a/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
+++ b/src/MiniExcel.OpenXml/Utils/XmlReaderHelper.cs
@@ -1,5 +1,3 @@
-using MiniExcelLib.OpenXml.Constants;
-
 namespace MiniExcelLib.OpenXml.Utils;
 
 internal static partial class XmlReaderHelper

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
@@ -118,7 +118,7 @@ internal partial class OpenXmlWriter
             var newStylesEntryStream = await newStylesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             var tempStylesEntryStream = await tempStylesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-#if NET8_0_OR_GREATER
+#if NET
             await using var disposableNewStylesEntryStream = newStylesEntryStream.ConfigureAwait(false);
             await using var disposableTempStylesEntryStream = tempStylesEntryStream.ConfigureAwait(false);
 #else
@@ -218,7 +218,7 @@ internal partial class OpenXmlWriter
     {
         var newEntry = _archive.CreateEntry(entry.FullName, CompressionLevel.Fastest);
 
-#if NET8_0_OR_GREATER
+#if NET
         var oldEntryStream = await _oldArchive!.GetEntry(entry.FullName)!.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var oldDisposableSheetStream = oldEntryStream.ConfigureAwait(false);
 
@@ -243,7 +243,7 @@ internal partial class OpenXmlWriter
             return;
         }
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
         var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
@@ -276,7 +276,7 @@ internal partial class OpenXmlWriter
 
         var contentTypesEntry = _archive.CreateEntry(ExcelFileNames.ContentTypes, CompressionLevel.Fastest);
         var contentTypesEntryStream = await contentTypesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-#if NET8_0_OR_GREATER
+#if NET
         await using var disposableContetTypesEntryStream = contentTypesEntryStream.ConfigureAwait(false);
         await doc.SaveAsync(contentTypesEntryStream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
 #else
@@ -308,7 +308,7 @@ internal partial class OpenXmlWriter
 #else
             Archive.Dispose();
 #endif
-#if NET8_0_OR_GREATER
+#if NET
             await _backingStream.DisposeAsync().ConfigureAwait(false);
 #else
             _backingStream.Dispose();

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
@@ -71,8 +71,8 @@ internal partial class OpenXmlWriter
         var sheetStylesBuilderUtils = await CopySheetStylesAndGetBuilderUtilsAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableSheetStylesBuilderUtils = sheetStylesBuilderUtils.ConfigureAwait(false);
 
-        await _sheetStyleBuildContext.DisposeAsync().ConfigureAwait(false);
-        _sheetStyleBuildContext = sheetStylesBuilderUtils.SheetStyleBuildContext;
+        await _sheetStyleBuilderContext.DisposeAsync().ConfigureAwait(false);
+        _sheetStyleBuilderContext = sheetStylesBuilderUtils.SheetStyleBuilderContext;
 
         var sharedStringsEntry = _oldArchive.GetEntry(ExcelFileNames.SharedStrings);
         if (sharedStringsEntry is not null)
@@ -101,8 +101,8 @@ internal partial class OpenXmlWriter
             entriesToIgnoreOnCopy.AddRange([
                 ExcelFileNames.Worksheet(_currentSheetIndex),
                 ExcelFileNames.SheetRels(_currentSheetIndex),
-                ExcelFileNames.Drawing(_currentSheetIndex - 1),
-                ExcelFileNames.DrawingRels(_currentSheetIndex - 1)
+                ExcelFileNames.Drawing(_currentSheetIndex),
+                ExcelFileNames.DrawingRels(_currentSheetIndex)
             ]);
         }
 
@@ -132,8 +132,8 @@ internal partial class OpenXmlWriter
         
         await AddFilesToZipAsync(cancellationToken).ConfigureAwait(false);
         await GenerateSharedStringsAsync(cancellationToken).ConfigureAwait(false);
-        await GenerateDrawingRelXmlAsync(_currentSheetIndex - 1, cancellationToken).ConfigureAwait(false);
-        await GenerateDrawingXmlAsync(_currentSheetIndex - 1, cancellationToken).ConfigureAwait(false);
+        await GenerateDrawingRelXmlAsync(_currentSheetIndex, cancellationToken).ConfigureAwait(false);
+        await GenerateDrawingXmlAsync(_currentSheetIndex, cancellationToken).ConfigureAwait(false);
         
         await CreateZipEntryAsync(
             ExcelFileNames.SheetRels(_currentSheetIndex),
@@ -184,10 +184,10 @@ internal partial class OpenXmlWriter
         backingStream.Seek(0, SeekOrigin.Begin);
         var copiedArchive = await ZipArchive.CreateAsync(backingStream, ZipArchiveMode.Update, true, Utf8WithBom, cancellationToken).ConfigureAwait(false);
 
-        SheetStyleBuildContext? oldStylesContext = null;
+        SheetStyleBuilderContext? oldStylesContext = null;
         try
         {
-            oldStylesContext = new SheetStyleBuildContext(_zipContentsMap, copiedArchive, Utf8WithBom);
+            oldStylesContext = new SheetStyleBuilderContext(_zipContentsMap, copiedArchive, Utf8WithBom);
             SheetStyleBuilderBase builder = _configuration.TableStyles switch
             {
                 TableStyles.None => new MinimalSheetStyleBuilder(oldStylesContext),
@@ -285,24 +285,24 @@ internal partial class OpenXmlWriter
 #endif
     }
     
-    private class TempSheetStylesBuilderUtils(Stream backingStream, ZipArchive archive, SheetStyleBuildContext sheetStyleBuildContext, ISheetStyleBuilder sheetStyleBuilder) : IDisposable, IAsyncDisposable
+    private class TempSheetStylesBuilderUtils(Stream backingStream, ZipArchive archive, SheetStyleBuilderContext sheetStyleBuilderContext, ISheetStyleBuilder sheetStyleBuilder) : IDisposable, IAsyncDisposable
     {
         private readonly Stream _backingStream = backingStream;
 
         public ZipArchive Archive { get; } = archive;
         public ISheetStyleBuilder SheetStyleBuilder { get; } = sheetStyleBuilder;
-        public SheetStyleBuildContext SheetStyleBuildContext { get; } = sheetStyleBuildContext;
+        public SheetStyleBuilderContext SheetStyleBuilderContext { get; } = sheetStyleBuilderContext;
 
         public void Dispose()
         {
-            SheetStyleBuildContext.Dispose();
+            SheetStyleBuilderContext.Dispose();
             Archive.Dispose();
             _backingStream.Dispose();
         }
 
         public async ValueTask DisposeAsync()
         {
-            await SheetStyleBuildContext.DisposeAsync().ConfigureAwait(false);
+            await SheetStyleBuilderContext.DisposeAsync().ConfigureAwait(false);
 #if NET10_0_OR_GREATER
             await Archive.DisposeAsync().ConfigureAwait(false);
 #else

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
@@ -246,11 +246,10 @@ internal partial class OpenXmlWriter
 #if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 #else
         using var stream = contentTypesZipEntry.Open();
-        var doc = XDocument.Load(stream);
 #endif
+        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
         var ns = doc.Root!.GetDefaultNamespace();
         var typesElement = doc.Descendants(ns + "Types").Single();
@@ -278,11 +277,10 @@ internal partial class OpenXmlWriter
         var contentTypesEntryStream = await contentTypesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
 #if NET
         await using var disposableContetTypesEntryStream = contentTypesEntryStream.ConfigureAwait(false);
-        await doc.SaveAsync(contentTypesEntryStream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
 #else
         using var disposableContetTypesEntryStream = contentTypesEntryStream;
-        doc.Save(contentTypesEntryStream);
 #endif
+        await doc.SaveAsync(contentTypesEntryStream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
     }
     
     private class TempSheetStylesBuilderUtils(Stream backingStream, ZipArchive archive, SheetStyleBuilderContext sheetStyleBuilderContext, ISheetStyleBuilder sheetStyleBuilder) : IDisposable, IAsyncDisposable

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
@@ -1,7 +1,3 @@
-using System.ComponentModel;
-using System.Xml.Linq;
-using MiniExcelLib.Core;
-using MiniExcelLib.OpenXml.Constants;
 using MiniExcelLib.OpenXml.Styles.Builder;
 
 namespace MiniExcelLib.OpenXml.Writer;

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.CopyInsert.cs
@@ -116,15 +116,10 @@ internal partial class OpenXmlWriter
         {
             var newStylesEntry = _archive.CreateEntry(ExcelFileNames.Styles, CompressionLevel.Fastest);
             var newStylesEntryStream = await newStylesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-            var tempStylesEntryStream = await tempStylesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-#if NET
             await using var disposableNewStylesEntryStream = newStylesEntryStream.ConfigureAwait(false);
+
+            var tempStylesEntryStream = await tempStylesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableTempStylesEntryStream = tempStylesEntryStream.ConfigureAwait(false);
-#else
-            using var disposableNewStylesEntryStream = newStylesEntryStream;
-            using var disposableTempStylesEntryStream = tempStylesEntryStream;
-#endif
 
             await tempStylesEntryStream.CopyToAsync(newStylesEntryStream, 81920, cancellationToken).ConfigureAwait(false);
             await newStylesEntryStream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -218,16 +213,11 @@ internal partial class OpenXmlWriter
     {
         var newEntry = _archive.CreateEntry(entry.FullName, CompressionLevel.Fastest);
 
-#if NET
         var oldEntryStream = await _oldArchive!.GetEntry(entry.FullName)!.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var oldDisposableSheetStream = oldEntryStream.ConfigureAwait(false);
 
         var newEntryStream = await newEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var newDisposableSheetStream = newEntryStream.ConfigureAwait(false);
-#else
-        using var oldEntryStream = await _oldArchive!.GetEntry(entry.FullName)!.OpenAsync(cancellationToken).ConfigureAwait(false);
-        using var newEntryStream = await newEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-#endif
 
         await oldEntryStream.CopyToAsync(newEntryStream, 81920, cancellationToken).ConfigureAwait(false);
         await newEntryStream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -243,14 +233,10 @@ internal partial class OpenXmlWriter
             return;
         }
 
-#if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = contentTypesZipEntry.Open();
-#endif
-        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 
+        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
         var ns = doc.Root!.GetDefaultNamespace();
         var typesElement = doc.Descendants(ns + "Types").Single();
 
@@ -275,11 +261,8 @@ internal partial class OpenXmlWriter
 
         var contentTypesEntry = _archive.CreateEntry(ExcelFileNames.ContentTypes, CompressionLevel.Fastest);
         var contentTypesEntryStream = await contentTypesEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
-#if NET
         await using var disposableContetTypesEntryStream = contentTypesEntryStream.ConfigureAwait(false);
-#else
-        using var disposableContetTypesEntryStream = contentTypesEntryStream;
-#endif
+
         await doc.SaveAsync(contentTypesEntryStream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
     }
     
@@ -306,11 +289,7 @@ internal partial class OpenXmlWriter
 #else
             Archive.Dispose();
 #endif
-#if NET
             await _backingStream.DisposeAsync().ConfigureAwait(false);
-#else
-            _backingStream.Dispose();
-#endif
         }
     }
 }

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.DefaultOpenXml.cs
@@ -216,23 +216,23 @@ internal partial class OpenXmlWriter
             var cellValue = GetNumericValue(value, type);
             if (columnMapping?.ExcelFormat is null)
             {
-                var dataType = ReferenceEquals(_configuration.Culture, CultureInfo.InvariantCulture) ? ExcelXml.NumericDataType : GetStringType();
+                var dataType = ReferenceEquals(_configuration.Culture, CultureInfo.InvariantCulture) ? ExcelDataTypes.Numeric : GetStringType();
                 return (RegularCellStyleIndex, dataType, cellValue);
             }
 
-            return (columnMapping.ExcelFormatId.ToString(), ExcelXml.NumericDataType, cellValue);
+            return (columnMapping.ExcelFormatId.ToString(), ExcelDataTypes.Numeric, cellValue);
         }
 
         if (type == typeof(bool))
-            return (RegularCellStyleIndex, ExcelXml.BooleanDataType, (bool)value ? "1" : "0");
+            return (RegularCellStyleIndex, ExcelDataTypes.Boolean, (bool)value ? "1" : "0");
 
         if (type == typeof(byte[]) && _configuration.EnableConvertByteArray)
         {
             if (!_configuration.EnableWriteFilePath)
-                return (FillCellStyleIndex, ExcelXml.CalculatedStringDataType, "");
+                return (FillCellStyleIndex, ExcelDataTypes.CalculatedString, "");
             
             var base64 = GetFileValue(rowIndex, cellIndex, value);
-            return (FillCellStyleIndex, ExcelXml.InlineStringDataType, base64);  
+            return (FillCellStyleIndex, ExcelDataTypes.InlineString, base64);  
         }
 
         return (RegularCellStyleIndex, GetStringType(), value.ToString());
@@ -240,11 +240,11 @@ internal partial class OpenXmlWriter
         string GetStringType()
         {
             if (columnMapping?.ExcelColumnType == ColumnType.Formula)
-                return ExcelXml.CalculatedStringDataType;
+                return ExcelDataTypes.CalculatedString;
             
             return _configuration.StringStorageMode == StringStorageMode.Shared 
-                ? ExcelXml.SharedStringDataType 
-                : ExcelXml.InlineStringDataType;
+                ? ExcelDataTypes.SharedString 
+                : ExcelDataTypes.InlineString;
         }
     }
 
@@ -332,14 +332,14 @@ internal partial class OpenXmlWriter
         if (!ReferenceEquals(_configuration.Culture, CultureInfo.InvariantCulture))
         {
             cellValue = value.ToString(_configuration.Culture);
-            return (RegularCellStyleIndex, ExcelXml.CalculatedStringDataType, cellValue);
+            return (RegularCellStyleIndex, ExcelDataTypes.CalculatedString, cellValue);
         }
 
         var oaDate = CorrectDateTimeValue(value);
         cellValue = oaDate.ToString(CultureInfo.InvariantCulture);
         var format = columnMapping?.ExcelFormatId is { } fmt and not -1 ? fmt.ToString() : DateCellStyleIndex;
 
-        return (format, ExcelXml.NumericDataType, cellValue);
+        return (format, ExcelDataTypes.Numeric, cellValue);
     }
 
     private static double CorrectDateTimeValue(DateTime value)
@@ -366,7 +366,7 @@ internal partial class OpenXmlWriter
         var cellValue = value.TotalDays.ToString(CultureInfo.InvariantCulture);
         var format = columnMapping?.ExcelFormatId is { } fmt and not -1 ? fmt.ToString() : TimeCellStyleIndex;
 
-        return (format, ExcelXml.NumericDataType, cellValue);
+        return (format, ExcelDataTypes.Numeric, cellValue);
     }
 
     private static string GetDimensionRef(int maxRowIndex, int maxColumnIndex)
@@ -383,7 +383,7 @@ internal partial class OpenXmlWriter
     private string GetDrawingRelationshipXml(int sheetIndex)
     {
         var drawing = new StringBuilder();
-        foreach (var image in _files.Where(w => w.IsImage && w.SheetId == sheetIndex + 1))
+        foreach (var image in _files.Where(w => w.IsImage && w.SheetId == sheetIndex))
         {
             drawing.AppendLine(ExcelXml.ImageRelationship(image));
         }
@@ -398,7 +398,7 @@ internal partial class OpenXmlWriter
         for (int fileIndex = 0; fileIndex < _files.Count; fileIndex++)
         {
             var file = _files[fileIndex];
-            if (file.IsImage && file.SheetId == sheetIndex + 1)
+            if (file.IsImage && file.SheetId == sheetIndex)
             {
                 drawing.Append(ExcelXml.DrawingXml(file, fileIndex));
             }

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.DefaultOpenXml.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.DefaultOpenXml.cs
@@ -188,7 +188,7 @@ internal partial class OpenXmlWriter
         if (type == typeof(TimeSpan))
             return GetTimeSpanValue((TimeSpan)value, columnMapping);
 
-#if NET8_0_OR_GREATER
+#if NET
         if (type == typeof(DateOnly))
             return GetDateTimeValue(((DateOnly)value).ToDateTime(default), columnMapping);
 

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.XmlGeneration.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.XmlGeneration.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel;
-using MiniExcelLib.Core.Attributes;
-using MiniExcelLib.OpenXml.Constants;
 using static MiniExcelLib.Core.Helpers.ImageHelper;
 
 namespace MiniExcelLib.OpenXml.Writer;

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -696,15 +696,15 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         if (newSheetName is null && newSheetIndex is null && newSheetState is null)
             return;
 
-        var oldWorkbookEntry = _archive.GetEntry("xl/workbook.xml")!;
+        var oldWorkbookEntry = _archive.GetEntry(ExcelFileNames.Workbook)!;
  
         try
         {
             var xmlDoc = await LoadWorkbook().ConfigureAwait(false);
 
             oldWorkbookEntry.Delete();
-            var newWorkbookEntry = _archive.CreateEntry("xl/workbook.xml", CompressionLevel.Fastest);
-#if NET
+            var newWorkbookEntry = _archive.CreateEntry(ExcelFileNames.Workbook, CompressionLevel.Fastest);
+
             var newZipStream = await newWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var newDisposableZipStream = newZipStream.ConfigureAwait(false);
             var writer = XmlWriter.Create(newZipStream, new XmlWriterSettings

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -176,7 +176,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         var entry = _archive.CreateEntry(sheetPath, CompressionLevel.Fastest);
         var rowsWritten = 0;
 
-#if NET8_0_OR_GREATER
+#if NET
         var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableZipStream = zipStream.ConfigureAwait(false);
 #else
@@ -500,7 +500,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
             var entry = _archive.CreateEntry(item.Path, CompressionLevel.Fastest);
 
-#if NET8_0_OR_GREATER
+#if NET
             var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
             await zipStream.WriteAsync(item.Contents, cancellationToken).ConfigureAwait(false);
@@ -632,7 +632,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
             return;
         }
 
-#if NET8_0_OR_GREATER
+#if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
         var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
@@ -664,7 +664,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         }
 
         stream.Position = 0;
-#if NET8_0_OR_GREATER
+#if NET
         await doc.SaveAsync(stream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
 #else
         doc.Save(stream);
@@ -678,7 +678,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
         var entry = _archive.CreateEntry(path, CompressionLevel.Fastest);
 
-#if NET8_0_OR_GREATER
+#if NET
         var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableZipStream = zipStream.ConfigureAwait(false);
 #else
@@ -709,7 +709,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
             oldWorkbookEntry.Delete();
             var newWorkbookEntry = _archive.CreateEntry("xl/workbook.xml", CompressionLevel.Fastest);
-#if NET8_0_OR_GREATER
+#if NET
             var newZipStream = await newWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var newDisposableZipStream = newZipStream.ConfigureAwait(false);
             var writer = XmlWriter.Create(newZipStream, new XmlWriterSettings
@@ -738,7 +738,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
         async Task<XDocument> LoadWorkbook()
         {
-#if NET8_0_OR_GREATER
+#if NET
             var zipStream = await oldWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
             var workbookDoc = await XDocument.LoadAsync(zipStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -22,8 +22,9 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
     private readonly bool _printHeader;
     private readonly object? _value;
 
-    private int _currentSheetIndex = 0;
-    private SheetStyleBuildContext _sheetStyleBuildContext;
+    // the index is 1-based to match how the rels work in OpenXml and to make it more intuitive to reason about them 
+    private int _currentSheetIndex;
+    private SheetStyleBuilderContext _sheetStyleBuilderContext;
 
 
     private OpenXmlWriter(Stream stream, ZipArchive archive, object? value, string sheetName, OpenXmlConfiguration configuration, bool printHeader)
@@ -37,7 +38,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         _printHeader = printHeader;
         _sheetName = sheetName;
 
-        _sheetStyleBuildContext = new SheetStyleBuildContext(_zipContentsMap, _archive, Utf8WithBom);
+        _sheetStyleBuilderContext = new SheetStyleBuilderContext(_zipContentsMap, _archive, Utf8WithBom);
     }
 
     [CreateSyncVersion]
@@ -67,7 +68,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 #endif
         await CreateZipEntryAsync(ExcelFileNames.Rels, ExcelContentTypes.Relationships, ExcelXml.DefaultRels, cancellationToken).ConfigureAwait(false);
 
-        await using var sbc = _sheetStyleBuildContext.ConfigureAwait(false);
+        await using var sbc = _sheetStyleBuilderContext.ConfigureAwait(false);
         var styleBuilder = await GetSheetStyleBuilderAsync(cancellationToken).ConfigureAwait(false);
 
         var sheets = GetSheets();
@@ -105,7 +106,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 #else
         using var disposableArchive = _archive;
 #endif
-        await using var sbc = _sheetStyleBuildContext.ConfigureAwait(false);
+        await using var sbc = _sheetStyleBuilderContext.ConfigureAwait(false);
 
         using var reader = await OpenXmlReader.CreateAsync(_stream, _configuration, cancellationToken: cancellationToken).ConfigureAwait(false);
         var rels = await reader.GetWorkbookRelsAsync(_archive.Entries, cancellationToken).ConfigureAwait(false) ?? [];
@@ -158,11 +159,11 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         sharedStringsEntry?.Delete();
         await GenerateSharedStringsAsync(cancellationToken).ConfigureAwait(false);
 
-        _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.DrawingRels(_currentSheetIndex - 1))?.Delete();
-        await GenerateDrawingRelXmlAsync(_currentSheetIndex - 1, cancellationToken).ConfigureAwait(false);
+        _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.DrawingRels(_currentSheetIndex))?.Delete();
+        await GenerateDrawingRelXmlAsync(_currentSheetIndex, cancellationToken).ConfigureAwait(false);
 
-        _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.Drawing(_currentSheetIndex - 1))?.Delete();
-        await GenerateDrawingXmlAsync(_currentSheetIndex - 1, cancellationToken).ConfigureAwait(false);
+        _archive.Entries.SingleOrDefault(s => s.FullName == ExcelFileNames.Drawing(_currentSheetIndex))?.Delete();
+        await GenerateDrawingXmlAsync(_currentSheetIndex, cancellationToken).ConfigureAwait(false);
         await GenerateWorkbookXmlAsync(true, cancellationToken).ConfigureAwait(false);
         await InsertContentTypesXmlAsync(cancellationToken).ConfigureAwait(false);
 
@@ -253,7 +254,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
                 return 0;
             }
 
-            _sheetStyleBuildContext.UpdateFormatIds(mappings);
+            _sheetStyleBuilderContext.UpdateFormatIds(mappings);
             
             int maxRowIndex;
             var maxColumnIndex = mappings.Count(x => x is { ExcelIgnoreColumn: false });
@@ -433,7 +434,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
                     continue;
 
                 var r = CellReferenceConverter.GetCellFromCoordinates(xIndex, yIndex);
-                await writer.WriteAsync(WorksheetXml.Cell(r, ExcelXml.InlineStringDataType, HeaderCellStyleIndex, map.ExcelColumnName), cancellationToken).ConfigureAwait(false);
+                await writer.WriteAsync(WorksheetXml.Cell(r, ExcelDataTypes.InlineString, HeaderCellStyleIndex, map.ExcelColumnName), cancellationToken).ConfigureAwait(false);
             }
             xIndex++;
         }
@@ -470,7 +471,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         widthCollection?.AdjustWidth(cellIndex, cellValue);
 
         if (_configuration.StringStorageMode == StringStorageMode.Shared && 
-            dataType == ExcelXml.SharedStringDataType 
+            dataType == ExcelDataTypes.SharedString 
             && cellValue is not null)
         {
             if (_sharedStrings.TryGetValue(cellValue, out var sharedStringIndex))
@@ -515,13 +516,13 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
     {
         SheetStyleBuilderBase builder = _configuration.TableStyles switch
         {
-            TableStyles.None => new MinimalSheetStyleBuilder(_sheetStyleBuildContext),
-            TableStyles.Default => new DefaultSheetStyleBuilder(_sheetStyleBuildContext, _configuration.StyleOptions),
+            TableStyles.None => new MinimalSheetStyleBuilder(_sheetStyleBuilderContext),
+            TableStyles.Default => new DefaultSheetStyleBuilder(_sheetStyleBuilderContext, _configuration.StyleOptions),
             _ => throw new InvalidEnumArgumentException(nameof(_configuration.TableStyles), (int)_configuration.TableStyles, typeof(TableStyles))
         };
 
         var newInfos = builder.GetGeneratedElementInfos();
-        await _sheetStyleBuildContext.CreateAsync(newInfos, cancellationToken).ConfigureAwait(false);
+        await _sheetStyleBuilderContext.CreateAsync(newInfos, cancellationToken).ConfigureAwait(false);
 
         return builder;
     }
@@ -529,7 +530,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
     [CreateSyncVersion]
     private async Task GenerateDrawingRelXmlAsync(CancellationToken cancellationToken)
     {
-        for (int sheetIndex = 0; sheetIndex < _sheets.Count; sheetIndex++)
+        for (int sheetIndex = 1; sheetIndex <= _sheets.Count; sheetIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await GenerateDrawingRelXmlAsync(sheetIndex, cancellationToken).ConfigureAwait(false);
@@ -550,7 +551,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
     [CreateSyncVersion]
     private async Task GenerateDrawingXmlAsync(CancellationToken cancellationToken)
     {
-        for (int sheetIndex = 0; sheetIndex < _sheets.Count; sheetIndex++)
+        for (int sheetIndex = 1; sheetIndex <= _sheets.Count; sheetIndex++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             await GenerateDrawingXmlAsync(sheetIndex, cancellationToken).ConfigureAwait(false);

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -635,12 +635,11 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 #if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 #else
         using var stream = contentTypesZipEntry.Open();
-        var doc = XDocument.Load(stream);
 #endif
 
+        var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
         var ns = doc.Root!.GetDefaultNamespace();
         var typesElement = doc.Descendants(ns + "Types").Single();
 
@@ -663,12 +662,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
             }
         }
 
-        stream.Position = 0;
-#if NET
+        stream.Seek(0, SeekOrigin.Begin);
         await doc.SaveAsync(stream, SaveOptions.None, cancellationToken).ConfigureAwait(false);
-#else
-        doc.Save(stream);
-#endif
     }
 
     [CreateSyncVersion]
@@ -741,11 +736,11 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 #if NET
             var zipStream = await oldWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
-            var workbookDoc = await XDocument.LoadAsync(zipStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
 #else
             using var zipStream = oldWorkbookEntry.Open();
-            var workbookDoc = XDocument.Load(zipStream);
 #endif
+
+            var workbookDoc = await XDocument.LoadAsync(zipStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
             var sheetsContainer = workbookDoc.Root?.Element((XNamespace)Schemas.SpreadsheetmlXmlMain + "sheets")!;
             var sheets = sheetsContainer.Elements().ToList();
 

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -176,12 +176,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
         var entry = _archive.CreateEntry(sheetPath, CompressionLevel.Fastest);
         var rowsWritten = 0;
 
-#if NET
         var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableZipStream = zipStream.ConfigureAwait(false);
-#else
-        using var zipStream = entry.Open();
-#endif
 
         var writer = new MiniExcelStreamWriter(zipStream, Utf8WithBom, _configuration.BufferSize);
         await using var disposableWriter = writer.ConfigureAwait(false);
@@ -500,12 +496,12 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
             var entry = _archive.CreateEntry(item.Path, CompressionLevel.Fastest);
 
-#if NET
             var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
+
+#if NET
             await zipStream.WriteAsync(item.Contents, cancellationToken).ConfigureAwait(false);
 #else
-            using var zipStream = entry.Open();
             await zipStream.WriteAsync(item.Contents, 0, item.Contents.Length, cancellationToken).ConfigureAwait(false);
 #endif
         }
@@ -632,12 +628,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
             return;
         }
 
-#if NET
         var stream = await contentTypesZipEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableStream = stream.ConfigureAwait(false);
-#else
-        using var stream = contentTypesZipEntry.Open();
-#endif
 
         var doc = await XDocument.LoadAsync(stream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
         var ns = doc.Root!.GetDefaultNamespace();
@@ -673,12 +665,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
         var entry = _archive.CreateEntry(path, CompressionLevel.Fastest);
 
-#if NET
         var zipStream = await entry.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var disposableZipStream = zipStream.ConfigureAwait(false);
-#else
-        using var zipStream = entry.Open();
-#endif
 
         var writer = new MiniExcelStreamWriter(zipStream, Utf8WithBom, _configuration.BufferSize);
         await using var disposableWriter = writer.ConfigureAwait(false);
@@ -707,6 +695,7 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
             var newZipStream = await newWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var newDisposableZipStream = newZipStream.ConfigureAwait(false);
+#if NET
             var writer = XmlWriter.Create(newZipStream, new XmlWriterSettings
             {
 #if !SYNC_ONLY
@@ -716,7 +705,6 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
             await using var disposableWriter = writer.ConfigureAwait(false);
             await xmlDoc.WriteToAsync(writer, CancellationToken.None).ConfigureAwait(false);
 #else
-            using var newZipStream = newWorkbookEntry.Open();
             using var writer = XmlWriter.Create(newZipStream, new XmlWriterSettings { Async = false });
             xmlDoc.WriteTo(writer);
 #endif
@@ -733,12 +721,8 @@ internal partial class OpenXmlWriter : IMiniExcelWriter
 
         async Task<XDocument> LoadWorkbook()
         {
-#if NET
             var zipStream = await oldWorkbookEntry.OpenAsync(cancellationToken).ConfigureAwait(false);
             await using var disposableZipStream = zipStream.ConfigureAwait(false);
-#else
-            using var zipStream = oldWorkbookEntry.Open();
-#endif
 
             var workbookDoc = await XDocument.LoadAsync(zipStream, LoadOptions.None, cancellationToken).ConfigureAwait(false);
             var sheetsContainer = workbookDoc.Root?.Element((XNamespace)Schemas.SpreadsheetmlXmlMain + "sheets")!;

--- a/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
+++ b/src/MiniExcel.OpenXml/Writer/OpenXmlWriter.cs
@@ -1,8 +1,4 @@
-using System.ComponentModel;
-using System.Xml.Linq;
-using MiniExcelLib.Core;
 using MiniExcelLib.Core.WriteAdapters;
-using MiniExcelLib.OpenXml.Constants;
 using MiniExcelLib.OpenXml.Styles.Builder;
 
 namespace MiniExcelLib.OpenXml.Writer;

--- a/tests/MiniExcel.Csv.Tests/AsyncIssueTests.cs
+++ b/tests/MiniExcel.Csv.Tests/AsyncIssueTests.cs
@@ -5,8 +5,6 @@ public class AsyncIssueTests
     private readonly CsvExporter _csvExporter = MiniExcel.Exporters.GetCsvExporter();
     private readonly CsvImporter _csvImporter = MiniExcel.Importers.GetCsvImporter();
 
-    private readonly OpenXmlExporter _openXmlExporter = MiniExcel.Exporters.GetOpenXmlExporter();
-    private readonly OpenXmlImporter _openXmlImporter = MiniExcel.Importers.GetOpenXmlImporter();
     /// <summary>
     /// Csv SaveAs by datareader with encoding default show messy code #253
     /// </summary>
@@ -111,60 +109,36 @@ public class AsyncIssueTests
     [Fact]
     public async Task Issue89()
     {
-        {
-            const string text =
-                """
-                State
-                OnDuty
-                Fired
-                Leave
-                """;
-            await using var stream = new MemoryStream();
-            await using var writer = new StreamWriter(stream);
+        const string text =
+            """
+            State
+            OnDuty
+            Fired
+            Leave
+            """;
 
-            await writer.WriteAsync(text);
-            await writer.FlushAsync();
+        await using var stream = new MemoryStream();
+        await using var writer = new StreamWriter(stream);
 
-            stream.Position = 0;
-            var q = _csvImporter.QueryAsync<Issue89Dto>(stream).ToBlockingEnumerable();
-            var rows = q.ToList();
+        await writer.WriteAsync(text);
+        await writer.FlushAsync();
 
-            Assert.Equal(Issue89Dto.WorkState.OnDuty, rows[0].State);
-            Assert.Equal(Issue89Dto.WorkState.Fired, rows[1].State);
-            Assert.Equal(Issue89Dto.WorkState.Leave, rows[2].State);
+        stream.Position = 0;
+        var rows1 = await _csvImporter.QueryAsync<Issue89Dto>(stream).ToListAsync();
 
-            var outputPath = PathHelper.GetTempPath();
-            var rowsWritten = await _openXmlExporter.ExportAsync(outputPath, rows);
-            Assert.Single(rowsWritten);
-            Assert.Equal(3, rowsWritten[0]);
+        Assert.Equal(Issue89Dto.WorkState.OnDuty, rows1[0].State);
+        Assert.Equal(Issue89Dto.WorkState.Fired, rows1[1].State);
+        Assert.Equal(Issue89Dto.WorkState.Leave, rows1[2].State);
 
-            var q2 = _openXmlImporter.QueryAsync<Issue89Dto>(outputPath).ToBlockingEnumerable();
-            var rows2 = q2.ToList();
-            Assert.Equal(Issue89Dto.WorkState.OnDuty, rows2[0].State);
-            Assert.Equal(Issue89Dto.WorkState.Fired, rows2[1].State);
-            Assert.Equal(Issue89Dto.WorkState.Leave, rows2[2].State);
-        }
+        var outputPath = PathHelper.GetTempPath();
+        var rowsWritten = await MiniExcel.Exporters.GetOpenXmlExporter().ExportAsync(outputPath, rows1);
+        Assert.Single(rowsWritten);
+        Assert.Equal(3, rowsWritten[0]);
 
-        //xlsx
-        {
-            var path = PathHelper.GetFile("xlsx/TestIssue89.xlsx");
-            var q = _openXmlImporter.QueryAsync<Issue89Dto>(path).ToBlockingEnumerable();
-            var rows = q.ToList();
-            Assert.Equal(Issue89Dto.WorkState.OnDuty, rows[0].State);
-            Assert.Equal(Issue89Dto.WorkState.Fired, rows[1].State);
-            Assert.Equal(Issue89Dto.WorkState.Leave, rows[2].State);
-
-            var outputPath = PathHelper.GetTempPath();
-            var rowsWritten = await _openXmlExporter.ExportAsync(outputPath, rows);
-            Assert.Single(rowsWritten);
-            Assert.Equal(3, rowsWritten[0]);
-
-            var q1 = _openXmlImporter.QueryAsync<Issue89Dto>(outputPath).ToBlockingEnumerable();
-            var rows2 = q1.ToList();
-            Assert.Equal(Issue89Dto.WorkState.OnDuty, rows2[0].State);
-            Assert.Equal(Issue89Dto.WorkState.Fired, rows2[1].State);
-            Assert.Equal(Issue89Dto.WorkState.Leave, rows2[2].State);
-        }
+        var rows2 = await MiniExcel.Importers.GetOpenXmlImporter().QueryAsync<Issue89Dto>(outputPath).ToListAsync();
+        Assert.Equal(Issue89Dto.WorkState.OnDuty, rows2[0].State);
+        Assert.Equal(Issue89Dto.WorkState.Fired, rows2[1].State);
+        Assert.Equal(Issue89Dto.WorkState.Leave, rows2[2].State);
     }
 
     private class Issue142VoDuplicateColumnName
@@ -184,76 +158,27 @@ public class AsyncIssueTests
     [Fact]
     public async Task Issue142()
     {
-        {
-            using var file = AutoDeletingPath.Create();
-            var path = file.ToString();
-            await _openXmlExporter.ExportAsync(path, new[] { new Issue142Dto { MyProperty1 = "MyProperty1", MyProperty2 = "MyProperty2", MyProperty3 = "MyProperty3", MyProperty4 = "MyProperty4", MyProperty5 = "MyProperty5", MyProperty6 = "MyProperty6", MyProperty7 = "MyProperty7" } });
+        using var file = AutoDeletingPath.Create(ExcelType.Csv);
+        var path = file.ToString();
 
-            {
-                var q = _openXmlImporter.QueryAsync(path).ToBlockingEnumerable();
-                var rows = q.ToList();
-                Assert.Equal("MyProperty4", rows[0].A);
-                Assert.Equal("CustomColumnName", rows[0].B); //note
-                Assert.Equal("MyProperty5", rows[0].C);
-                Assert.Equal("MyProperty2", rows[0].D);
-                Assert.Equal("MyProperty6", rows[0].E);
-                Assert.Null(rows[0].F);
-                Assert.Equal("MyProperty3", rows[0].G);
+        await _csvExporter.ExportAsync(path, new[] { new Issue142Dto { MyProperty1 = "MyProperty1", MyProperty2 = "MyProperty2", MyProperty3 = "MyProperty3", MyProperty4 = "MyProperty4", MyProperty5 = "MyProperty5", MyProperty6 = "MyProperty6", MyProperty7 = "MyProperty7" } });
+        const string expected =
+            """
+            MyProperty4,CustomColumnName,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
+            MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
 
-                Assert.Equal("MyProperty4", rows[0].A);
-                Assert.Equal("CustomColumnName", rows[0].B); //note
-                Assert.Equal("MyProperty5", rows[0].C);
-                Assert.Equal("MyProperty2", rows[0].D);
-                Assert.Equal("MyProperty6", rows[0].E);
-                Assert.Null(rows[0].F);
-                Assert.Equal("MyProperty3", rows[0].G);
-            }
+            """;
 
-            {
-                var q = _openXmlImporter.QueryAsync<Issue142Dto>(path).ToBlockingEnumerable();
-                var rows = q.ToList();
+        Assert.Equal(expected, await File.ReadAllTextAsync(path));
+        var rows = await _csvImporter.QueryAsync<Issue142Dto>(path).ToListAsync();
 
-                Assert.Equal("MyProperty4", rows[0].MyProperty4);
-                Assert.Equal("MyProperty1", rows[0].MyProperty1); //note
-                Assert.Equal("MyProperty5", rows[0].MyProperty5);
-                Assert.Equal("MyProperty2", rows[0].MyProperty2);
-                Assert.Equal("MyProperty6", rows[0].MyProperty6);
-                Assert.Null(rows[0].MyProperty7);
-                Assert.Equal("MyProperty3", rows[0].MyProperty3);
-            }
-        }
-
-        {
-            using var file = AutoDeletingPath.Create(ExcelType.Csv);
-            var path = file.ToString();
-            await _csvExporter.ExportAsync(path, new[] { new Issue142Dto { MyProperty1 = "MyProperty1", MyProperty2 = "MyProperty2", MyProperty3 = "MyProperty3", MyProperty4 = "MyProperty4", MyProperty5 = "MyProperty5", MyProperty6 = "MyProperty6", MyProperty7 = "MyProperty7" } });
-            const string expected =
-                """
-                MyProperty4,CustomColumnName,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
-                MyProperty4,MyProperty1,MyProperty5,MyProperty2,MyProperty6,,MyProperty3
-
-                """;
-            Assert.Equal(expected, await File.ReadAllTextAsync(path));
-
-            {
-                var q = _csvImporter.QueryAsync<Issue142Dto>(path).ToBlockingEnumerable();
-                var rows = q.ToList();
-
-                Assert.Equal("MyProperty4", rows[0].MyProperty4);
-                Assert.Equal("MyProperty1", rows[0].MyProperty1);
-                Assert.Equal("MyProperty5", rows[0].MyProperty5);
-                Assert.Equal("MyProperty2", rows[0].MyProperty2);
-                Assert.Equal("MyProperty6", rows[0].MyProperty6);
-                Assert.Null(rows[0].MyProperty7);
-                Assert.Equal("MyProperty3", rows[0].MyProperty3);
-            }
-        }
-
-        {
-            using var path = AutoDeletingPath.Create();
-            Issue142VoDuplicateColumnName[] input = [new() { MyProperty1 = 0, MyProperty2 = 0, MyProperty3 = 0, MyProperty4 = 0 }];
-            Assert.Throws<InvalidMappingException>(() => _openXmlExporter.Export(path.ToString(), input));
-        }
+        Assert.Equal("MyProperty4", rows[0].MyProperty4);
+        Assert.Equal("MyProperty1", rows[0].MyProperty1);
+        Assert.Equal("MyProperty5", rows[0].MyProperty5);
+        Assert.Equal("MyProperty2", rows[0].MyProperty2);
+        Assert.Equal("MyProperty6", rows[0].MyProperty6);
+        Assert.Null(rows[0].MyProperty7);
+        Assert.Equal("MyProperty3", rows[0].MyProperty3);
     }
     
     /// <summary>
@@ -273,8 +198,7 @@ public class AsyncIssueTests
         using var path = AutoDeletingPath.Create(ExcelType.Csv);
         await  _csvExporter.ExportAsync(path.ToString(), table);
 
-        var q =  _csvImporter.QueryAsync(path.ToString()).ToBlockingEnumerable();
-        var rows = q.ToList();
+        var rows = await _csvImporter.QueryAsync(path.ToString()).ToListAsync();
         Assert.Equal("Name", rows[0].B);
         Assert.Equal("Limit", rows[0].C);
     }
@@ -295,9 +219,7 @@ public class AsyncIssueTests
         };
         await  _csvExporter.ExportAsync(path.ToString(), value);
 
-        var q =  _csvImporter.QueryAsync(path.ToString(), true).ToBlockingEnumerable();
-        var rows = q.ToList();
-
+        var rows = await _csvImporter.QueryAsync(path.ToString(), true).ToListAsync();
         Assert.Equal("\"\"1,2,3\"\"", rows[0].id);
         Assert.Equal("1,2,3", rows[1].id);
     }
@@ -322,13 +244,11 @@ public class AsyncIssueTests
         Assert.Single(rowsWritten);
         Assert.Equal(2, rowsWritten[0]);
 
-        var q1 = _csvImporter.QueryAsync(path, true).ToBlockingEnumerable();
-        var rows1 = q1.ToList();
+        var rows1 = await _csvImporter.QueryAsync(path, true).ToListAsync();
         Assert.Equal(rows1[0].InDate, "01 04, 2021");
         Assert.Equal(rows1[1].InDate, "04 05, 2020");
 
-        var q2 = _csvImporter.QueryAsync<Issue241Dto>(path).ToBlockingEnumerable();
-        var rows2 = q2.ToList();
+        var rows2 = await _csvImporter.QueryAsync<Issue241Dto>(path).ToListAsync();
         Assert.Equal(rows2[0].InDate, new DateTime(2021, 01, 04));
         Assert.Equal(rows2[1].InDate, new DateTime(2020, 04, 05));
     }
@@ -343,17 +263,16 @@ public class AsyncIssueTests
         using var path = AutoDeletingPath.Create(ExcelType.Csv);
         var value = new[] 
         {
-            new { Name ="Jack",Age=25,InDate=new DateTime(2021,01,03)},
-            new { Name ="Henry",Age=36,InDate=new DateTime(2020,05,03)},
+            new { Name = "Jack", Age = 25, InDate = new DateTime(2021,01,03) },
+            new { Name = "Henry", Age = 36, InDate = new DateTime(2020,05,03) }
         };
         
         var rowsWritten = await  _csvExporter.ExportAsync(path.ToString(), value);
         Assert.Single(rowsWritten);
         Assert.Equal(2, rowsWritten[0]);
 
-        var q =  _csvImporter.QueryAsync<Issue243Dto>(path.ToString()).ToBlockingEnumerable();
-        var rows = q.ToList();
-        
+        var rows = await _csvImporter.QueryAsync<Issue243Dto>(path.ToString()).ToListAsync();
+
         Assert.Equal("Jack", rows[0].Name);
         Assert.Equal(25, rows[0].Age);
         Assert.Equal(new DateTime(2021, 01, 03), rows[0].InDate);

--- a/tests/MiniExcel.Csv.Tests/IssueTests.cs
+++ b/tests/MiniExcel.Csv.Tests/IssueTests.cs
@@ -324,81 +324,6 @@ public class IssueTests
     [Fact]
     public void TestIssue316()
     {
-        // XLSX
-        {
-            using var file = AutoDeletingPath.Create();
-            var path = file.ToString();
-            var value = new[]
-            {
-                new{ Amount=123_456.789M, CreateTime=DateTime.Parse("2018-01-31",CultureInfo.InvariantCulture)}
-            };
-            var config = new OpenXmlConfiguration
-            {
-                Culture = new CultureInfo("fr-FR"),
-            };
-            _openXmlExporter.Export(path, value, configuration: config);
-
-            //Datetime error
-            Assert.Throws<ValueNotAssignableException>(() =>
-            {
-                var conf = new OpenXmlConfiguration
-                {
-                    Culture = new CultureInfo("en-US"),
-                };
-                _ = _openXmlImporter.Query<TestIssue316Dto>(path, configuration: conf).ToList();
-            });
-
-            // dynamic
-            var rows = _openXmlImporter.Query(path, true).ToList();
-            Assert.Equal("123456,789", rows[0].Amount);
-            Assert.Equal("31/01/2018 00:00:00", rows[0].CreateTime);
-        }
-
-        // type
-        {
-            using var file = AutoDeletingPath.Create();
-            var path = file.ToString();
-            var value = new[]
-            {
-                new { Amount = 123_456.789M, CreateTime = new DateTime(2018, 5, 12) }
-            };
-            {
-                var config = new OpenXmlConfiguration
-                {
-                    Culture = new CultureInfo("fr-FR"),
-                };
-                _openXmlExporter.Export(path, value, configuration: config);
-            }
-
-            {
-                var rows = _openXmlImporter.Query(path, true).ToList();
-                Assert.Equal("123456,789", rows[0].Amount);
-                Assert.Equal("12/05/2018 00:00:00", rows[0].CreateTime);
-            }
-
-            {
-                var config = new OpenXmlConfiguration
-                {
-                    Culture = new CultureInfo("en-US"),
-                };
-                var rows = _openXmlImporter.Query<TestIssue316Dto>(path, configuration: config).ToList();
-
-                Assert.Equal("2018-12-05 00:00:00", rows[0].CreateTime.ToString("yyyy-MM-dd HH:mm:ss"));
-                Assert.Equal(123456789m, rows[0].Amount);
-            }
-
-            {
-                var config = new OpenXmlConfiguration
-                {
-                    Culture = new CultureInfo("fr-FR"),
-                };
-                var rows = _openXmlImporter.Query<TestIssue316Dto>(path, configuration: config).ToList();
-
-                Assert.Equal("2018-05-12 00:00:00", rows[0].CreateTime.ToString("yyyy-MM-dd HH:mm:ss"));
-                Assert.Equal(123456.789m, rows[0].Amount);
-            }
-        }
-
         // CSV
         {
             using var file = AutoDeletingPath.Create(ExcelType.Csv);
@@ -677,53 +602,33 @@ public class IssueTests
     public void Issue89()
     {
         //csv
-        {
-            const string text =
-               """
-               State
-               OnDuty
-               Fired
-               Leave
-               """;
+        const string text =
+            """
+            State
+            OnDuty
+            Fired
+            Leave
+            """;
 
-            using var stream = new MemoryStream();
-            using var writer = new StreamWriter(stream);
+        using var stream = new MemoryStream();
+        using var writer = new StreamWriter(stream);
 
-            writer.Write(text);
-            writer.Flush();
-            stream.Position = 0;
-            var rows = _csvImporter.Query(stream, useHeaderRow: true).ToList();
+        writer.Write(text);
+        writer.Flush();
+        stream.Position = 0;
+        var rows = _csvImporter.Query(stream, useHeaderRow: true).ToList();
 
-            Assert.Equal(nameof(Issue89Model.WorkState.OnDuty), rows[0].State);
-            Assert.Equal(nameof(Issue89Model.WorkState.Fired), rows[1].State);
-            Assert.Equal(nameof(Issue89Model.WorkState.Leave), rows[2].State);
+        Assert.Equal(nameof(Issue89Model.WorkState.OnDuty), rows[0].State);
+        Assert.Equal(nameof(Issue89Model.WorkState.Fired), rows[1].State);
+        Assert.Equal(nameof(Issue89Model.WorkState.Leave), rows[2].State);
 
-            using var path = AutoDeletingPath.Create(ExcelType.Csv);
-            _csvExporter.Export(path.ToString(), rows);
-            var rows2 = _csvImporter.Query<Issue89Model>(path.ToString()).ToList();
+        using var path = AutoDeletingPath.Create(ExcelType.Csv);
+        _csvExporter.Export(path.ToString(), rows);
+        var rows2 = _csvImporter.Query<Issue89Model>(path.ToString()).ToList();
 
-            Assert.Equal(Issue89Model.WorkState.OnDuty, rows2[0].State);
-            Assert.Equal(Issue89Model.WorkState.Fired, rows2[1].State);
-            Assert.Equal(Issue89Model.WorkState.Leave, rows2[2].State);
-        }
-
-        //xlsx
-        {
-            var path = PathHelper.GetFile("xlsx/TestIssue89.xlsx");
-            var rows = _openXmlImporter.Query<Issue89Model>(path).ToList();
-
-            Assert.Equal(Issue89Model.WorkState.OnDuty, rows[0].State);
-            Assert.Equal(Issue89Model.WorkState.Fired, rows[1].State);
-            Assert.Equal(Issue89Model.WorkState.Leave, rows[2].State);
-
-            using var xlsxPath = AutoDeletingPath.Create();
-            _openXmlExporter.Export(xlsxPath.ToString(), rows);
-            var rows2 = _openXmlImporter.Query<Issue89Model>(xlsxPath.ToString()).ToList();
-
-            Assert.Equal(Issue89Model.WorkState.OnDuty, rows2[0].State);
-            Assert.Equal(Issue89Model.WorkState.Fired, rows2[1].State);
-            Assert.Equal(Issue89Model.WorkState.Leave, rows2[2].State);
-        }
+        Assert.Equal(Issue89Model.WorkState.OnDuty, rows2[0].State);
+        Assert.Equal(Issue89Model.WorkState.Fired, rows2[1].State);
+        Assert.Equal(Issue89Model.WorkState.Leave, rows2[2].State);
     }
 
     private class Issue142VoDuplicateColumnName

--- a/tests/MiniExcel.OpenXml.Tests/MiniExcelOpenXmlAsyncTests.cs
+++ b/tests/MiniExcel.OpenXml.Tests/MiniExcelOpenXmlAsyncTests.cs
@@ -388,9 +388,7 @@ public class MiniExcelOpenXmlAsyncTests
     [InlineData("../../../../data/xlsx/TestCenterEmptyRow/TestCenterEmptyRow.xlsx")]
     public async Task QueryExcelDataReaderCheckTest(string path)
     {
-#if NETCOREAPP3_1_OR_GREATER
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-#endif
 
         await using var fs = File.OpenRead(path);
         using var reader = ExcelReaderFactory.CreateReader(fs);

--- a/tests/MiniExcel.OpenXml.Tests/MiniExcelOpenXmlTests.cs
+++ b/tests/MiniExcel.OpenXml.Tests/MiniExcelOpenXmlTests.cs
@@ -455,9 +455,8 @@ public class MiniExcelOpenXmlTests(ITestOutputHelper output)
     [InlineData("../../../../data/xlsx/TestCenterEmptyRow/TestCenterEmptyRow.xlsx")]
     public void QueryDataReaderCheckTest(string path)
     {
-#if NETCOREAPP3_1_OR_GREATER
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-#endif
+
         using var fs = File.OpenRead(path);
         using var reader = ExcelReaderFactory.CreateReader(fs);
         var exceldatareaderResult = reader.AsDataSet();


### PR DESCRIPTION
#### This PR brings many QOL improvements to improve the readability of the codebase, namely:

- Added `Stream.DisposeAsync` polyfill alongside a `StreamConfiguredAsyncDisposable` (mirroring the runtimes's `ConfiguredAsyncDisposable`). This allowed clearing most of the preprocessor directives throughout codebase
- Simplified the remaining directives between `#if NETCOREAPP2_0` and `#if NET8_0` to the simpler `#if NET`
- Added Dictionary<TKey, TValue>.TryAdd, `XDocument.LoadAsync` and `XDocument.SaveAsync` polyfills
- Added more constants to `Schemas` and `Excel.Filenames`, and substituted them where they had been prevoiusly hardcoded
- Removed obsolete `FillTemplate` method overloads from `OpenXmlTemplater`
- Other minor refactorings