### PR TITLE
fix: template rendering corrupts workbooks that contain formulas (calcChain + $= cell serialization)

### DIFF
--- a/README-NuGet.md
+++ b/README-NuGet.md
@@ -1,10 +1,5 @@
 ## MiniExcel
-[![NuGet Version](https://img.shields.io/nuget/v/MiniExcel.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;
-[![NuGet Downloads](https://img.shields.io/nuget/dt/MiniExcel.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;
-[![GitHub Stars](https://img.shields.io/github/stars/mini-software/MiniExcel?logo=github)](https://github.com/mini-software/MiniExcel)&nbsp;
-[![Gitee Stars](https://gitee.com/dotnetchina/MiniExcel/badge/star.svg)](https://gitee.com/dotnetchina/MiniExcel)&nbsp;
-[![.NET Version](https://img.shields.io/badge/.NET-%3E%3D%204.5-red.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;
-[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mini-software/MiniExcel)
+[![NuGet Version](https://img.shields.io/nuget/v/MiniExcel.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;[![NuGet Downloads](https://img.shields.io/nuget/dt/MiniExcel.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;[![GitHub Stars](https://img.shields.io/github/stars/mini-software/MiniExcel?logo=github)](https://github.com/mini-software/MiniExcel)&nbsp;[![Gitee Stars](https://gitee.com/dotnetchina/MiniExcel/badge/star.svg)](https://gitee.com/dotnetchina/MiniExcel)&nbsp;[![.NET Version](https://img.shields.io/badge/.NET-%3E%3D%204.5-red.svg)](https://www.nuget.org/packages/MiniExcel)&nbsp;[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/mini-software/MiniExcel)
 
 This project is part of the [.NET Foundation](https://dotnetfoundation.org/projects/project-detail/miniexcel) and operates under their code of conduct.
 

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -1008,19 +1008,21 @@ internal partial class ExcelOpenXmlTemplate
 
                     // create the f element with the document's prefix: an unprefixed element would rely on a
                     // default xmlns declaration that CleanXml strips, leaving <f> in no namespace (invalid for Excel)
-                    var fNode = c.OwnerDocument.CreateElement(c.Prefix, "f", Config.SpreadsheetmlXmlns);
+                    var fNode = c.OwnerDocument!.CreateElement(c.Prefix, "f", Config.SpreadsheetmlXmlns);
                     fNode.InnerText = v.InnerText.Substring(2);
                     c.InsertBefore(fNode, v);
                     c.RemoveChild(v);
+
                     // the cell no longer holds an inline string; keeping t="inlineStr" without <is> is invalid
                     c.RemoveAttribute("t");
 
-                    // take the column from the cell's own reference — the position in the child list is wrong
-                    // for sparse rows (cells without content are not emitted)
+                    // take the column from the cell's own reference —
+                    // the position in the child list is wrong for sparse rows (cells without content are not emitted)
                     var rAttr = c.GetAttribute("r");
                     var celRef = string.IsNullOrEmpty(rAttr)
                         ? ExcelOpenXmlUtils.ConvertXyToCell(ci + 1, rowIndex)
                         : rAttr;
+
                     _calcChainCellRefs.Add(celRef);
                 }
             }
@@ -1084,7 +1086,8 @@ internal partial class ExcelOpenXmlTemplate
                 c.AppendChild(isNode);
 
                 c.RemoveAttribute("t");
-                c.SetAttribute("t", "inlineStr");                }
+                c.SetAttribute("t", "inlineStr");
+            }
         }
     }
 

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -1017,10 +1017,10 @@ internal partial class ExcelOpenXmlTemplate
 
                     // take the column from the cell's own reference — the position in the child list is wrong
                     // for sparse rows (cells without content are not emitted)
-                    var columnLetters = new string(c.GetAttribute("r").TakeWhile(char.IsLetter).ToArray());
-                    var celRef = string.IsNullOrEmpty(columnLetters)
+                    var rAttr = c.GetAttribute("r");
+                    var celRef = string.IsNullOrEmpty(rAttr)
                         ? ExcelOpenXmlUtils.ConvertXyToCell(ci + 1, rowIndex)
-                        : $"{columnLetters}{rowIndex}";
+                        : rAttr;
                     _calcChainCellRefs.Add(celRef);
                 }
             }

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -1006,12 +1006,21 @@ internal partial class ExcelOpenXmlTemplate
                     if (!v.InnerText.StartsWith("$="))
                         continue;
 
-                    var fNode = c.OwnerDocument.CreateElement("f", Config.SpreadsheetmlXmlns);
+                    // create the f element with the document's prefix: an unprefixed element would rely on a
+                    // default xmlns declaration that CleanXml strips, leaving <f> in no namespace (invalid for Excel)
+                    var fNode = c.OwnerDocument.CreateElement(c.Prefix, "f", Config.SpreadsheetmlXmlns);
                     fNode.InnerText = v.InnerText.Substring(2);
                     c.InsertBefore(fNode, v);
                     c.RemoveChild(v);
+                    // the cell no longer holds an inline string; keeping t="inlineStr" without <is> is invalid
+                    c.RemoveAttribute("t");
 
-                    var celRef = ExcelOpenXmlUtils.ConvertXyToCell(ci + 1, rowIndex);
+                    // take the column from the cell's own reference — the position in the child list is wrong
+                    // for sparse rows (cells without content are not emitted)
+                    var columnLetters = new string(c.GetAttribute("r").TakeWhile(char.IsLetter).ToArray());
+                    var celRef = string.IsNullOrEmpty(columnLetters)
+                        ? ExcelOpenXmlUtils.ConvertXyToCell(ci + 1, rowIndex)
+                        : $"{columnLetters}{rowIndex}";
                     _calcChainCellRefs.Add(celRef);
                 }
             }

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
@@ -4,6 +4,7 @@ using System.IO.Compression;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace MiniExcelLibs.OpenXml.SaveByTemplate;
 
@@ -81,10 +82,10 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
             // Iterate through each entry in the original archive
             foreach (ZipArchiveEntry entry in originalArchive.Entries)
             {
-                if (entry.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
-                    entry.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
-                    entry.FullName.Contains("xl/calcChain.xml")
-                   )
+                if (entry.FullName.TrimStart('/').StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
+                    entry.FullName.Contains("xl/calcChain.xml") ||
+                    entry.FullName.Contains("workbook.xml.rels") ||
+                    entry.FullName.Contains("[Content_Types].xml"))
                     continue;
                     
                 // Create a new entry in the new archive with the same name
@@ -132,7 +133,21 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
                 }
             }
 
-            // create mode we need to not create first then create here
+            // loading [Content_Types] and workbook.rels for later editing and saving
+            XDocument wbRelsDoc;
+            var wbRelsEntry = originalArchive.Entries.First(e => e.FullName.Contains("workbook.xml.rels"));
+            using (var wbRelsStream = wbRelsEntry.Open())
+            {
+                wbRelsDoc = XDocument.Load(wbRelsStream);
+            }
+
+            XDocument cTypesDoc;
+            var cTypesEntry = originalArchive.Entries.First(e => e.FullName.Contains("[Content_Types].xml"));
+            using (var cTypesStream = cTypesEntry.Open())
+            {
+                cTypesDoc = XDocument.Load(cTypesStream);
+            }
+            
             // The template's own calcChain cannot be reused: row insertion shifts formula cells and its
             // entries would point at the old addresses. It is regenerated from the rendered formulas —
             // and when none were rendered, dropped entirely, because a calcChain with no <c> entries is
@@ -145,10 +160,31 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
                 //calcChain.Delete();
 
                 var calcChainEntry = outputFileArchive.zipFile.CreateEntry(calcChainPathName);
-                using (var calcChainStream = calcChainEntry.Open())
-                {
-                    CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());
-                }
+                using var calcChainStream = calcChainEntry.Open();
+                CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());
+            }
+            else
+            {
+                // removing calcChain.xml entry from [Content_Types] and workbook.rels
+                wbRelsDoc.Root?.Elements()
+                    .FirstOrDefault(x => x.Attribute("Target")?.Value.Contains("calcChain.xml") is true)
+                    ?.Remove();
+                
+                cTypesDoc.Root?.Elements()
+                    .FirstOrDefault(x => x.Attribute("PartName")?.Value.Contains("calcChain.xml") is true)
+                    ?.Remove();
+            }
+            
+            var newWbRelsEntry = outputFileArchive.zipFile.CreateEntry(wbRelsEntry.FullName);
+            using (var newWbRelsEntryStream = newWbRelsEntry.Open())
+            {
+                wbRelsDoc.Save(newWbRelsEntryStream);
+            }
+            
+            var newCTypesEntry = outputFileArchive.zipFile.CreateEntry(cTypesEntry.FullName);
+            using (var newCTypesEntryStream = newCTypesEntry.Open())
+            {
+                cTypesDoc.Save(newCTypesEntryStream);
             }
 
             outputFileArchive.zipFile.Dispose();

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
@@ -58,6 +58,7 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
             
         var templateReader = new ExcelOpenXmlSheetReader(templateStream, null);
         var outputFileArchive = new ExcelOpenXmlZip(_outputFileStream, mode: ZipArchiveMode.Create, true, Encoding.UTF8, isUpdateMode: false);
+
         try
         {
             outputFileArchive.entries = templateReader._archive.zipFile.Entries; //TODO:need to remove
@@ -71,14 +72,10 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
         {
             outputFileArchive._entries.Add(entry.FullName.Replace('\\', '/'), entry);
         }
-            
+
         templateStream.Position = 0;
         using (var originalArchive = new ZipArchive(templateStream, ZipArchiveMode.Read))
         {
-            // Create a new zip file for writing
-            //using (FileStream newZipStream = new FileStream(newZipPath, FileMode.Create))
-            //using (ZipArchive newArchive = new ZipArchive(_outputFileStream, ZipArchiveMode.Create))
-                
             // Iterate through each entry in the original archive
             foreach (ZipArchiveEntry entry in originalArchive.Entries)
             {
@@ -87,7 +84,7 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
                     entry.FullName.Contains("workbook.xml.rels") ||
                     entry.FullName.Contains("[Content_Types].xml"))
                     continue;
-                    
+
                 // Create a new entry in the new archive with the same name
                 var newEntry = outputFileArchive.zipFile.CreateEntry(entry.FullName);
 
@@ -105,9 +102,7 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
 
             //read all xlsx sheets
             var templateSheets = templateReader._archive.zipFile.Entries
-                .Where(w =>
-                    w.FullName.StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase) ||
-                    w.FullName.StartsWith("/xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase));
+                .Where(w => w.FullName.TrimStart('/').StartsWith("xl/worksheets/sheet", StringComparison.OrdinalIgnoreCase));
 
             int sheetIdx = 0;
             foreach (var templateSheet in templateSheets)
@@ -151,14 +146,12 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
             // The template's own calcChain cannot be reused: row insertion shifts formula cells and its
             // entries would point at the old addresses. It is regenerated from the rendered formulas —
             // and when none were rendered, dropped entirely, because a calcChain with no <c> entries is
-            // schema-invalid and Excel rejects the whole package either way. Excel rebuilds the chain
-            // on open, so dropping it is always safe.
+            // schema-invalid and Excel rejects the whole package either way.
+            // Excel rebuilds the chain on open, so dropping it is always safe.
             var calcChain = outputFileArchive.entries.FirstOrDefault(e => e.FullName.Contains("xl/calcChain.xml"));
             if (calcChain != null && _calcChainContent.Length > 0)
             {
                 var calcChainPathName = calcChain.FullName;
-                //calcChain.Delete();
-
                 var calcChainEntry = outputFileArchive.zipFile.CreateEntry(calcChainPathName);
                 using var calcChainStream = calcChainEntry.Open();
                 CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());

--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.cs
@@ -128,12 +128,18 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
                     // disposing writer disposes streams as well. read and parse calc functions before that
                     sheetIdx++;
                     _calcChainContent.Append(CalcChainHelper.GetCalcChainContent(_calcChainCellRefs, sheetIdx));
+                    _calcChainCellRefs.Clear();
                 }
             }
 
             // create mode we need to not create first then create here
+            // The template's own calcChain cannot be reused: row insertion shifts formula cells and its
+            // entries would point at the old addresses. It is regenerated from the rendered formulas —
+            // and when none were rendered, dropped entirely, because a calcChain with no <c> entries is
+            // schema-invalid and Excel rejects the whole package either way. Excel rebuilds the chain
+            // on open, so dropping it is always safe.
             var calcChain = outputFileArchive.entries.FirstOrDefault(e => e.FullName.Contains("xl/calcChain.xml"));
-            if (calcChain != null)
+            if (calcChain != null && _calcChainContent.Length > 0)
             {
                 var calcChainPathName = calcChain.FullName;
                 //calcChain.Delete();
@@ -142,23 +148,6 @@ internal partial class ExcelOpenXmlTemplate : IExcelTemplate, IExcelTemplateAsyn
                 using (var calcChainStream = calcChainEntry.Open())
                 {
                     CalcChainHelper.GenerateCalcChainSheet(calcChainStream, _calcChainContent.ToString());
-                }
-            }
-            else
-            {
-                foreach (ZipArchiveEntry entry in originalArchive.Entries)
-                {
-                    if (entry.FullName.Contains("xl/calcChain.xml"))
-                    {
-                        var newEntry = outputFileArchive.zipFile.CreateEntry(entry.FullName);
-
-                        // Copy the content of the original entry to the new entry
-                        using (Stream originalEntryStream = entry.Open())
-                        using (Stream newEntryStream = newEntry.Open())
-                        {
-                            originalEntryStream.CopyTo(newEntryStream);
-                        }
-                    }
                 }
             }
 

--- a/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateCalcChainTests.cs
+++ b/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateCalcChainTests.cs
@@ -33,7 +33,16 @@ public class MiniExcelTemplateCalcChainTests
         }
 
         using var path = AutoDeletingPath.Create();
-        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, TwoItemValues());
+        Dictionary<string, object?> data = new()
+        {
+            ["title"] = "FooCompany",
+            ["items"] = new[]
+            {
+                new { Name = "A", Qty = 1 },
+                new { Name = "B", Qty = 2 },
+            }
+        };
+        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, data);
 
         using var zip = ZipFile.OpenRead(path.ToString());
         var calcChain = zip.GetEntry("xl/calcChain.xml");
@@ -41,7 +50,7 @@ public class MiniExcelTemplateCalcChainTests
         {
             using var reader = new StreamReader(calcChain.Open());
             var content = reader.ReadToEnd();
-            Assert.Contains("<c ", content);       // an empty calcChain is schema-invalid
+            Assert.Contains("<c ", content); // an empty calcChain is schema-invalid
             Assert.DoesNotContain(@"r=""B5""", content); // the pre-render address is stale after the row shift
         }
     }
@@ -68,14 +77,26 @@ public class MiniExcelTemplateCalcChainTests
         }
 
         using var path = AutoDeletingPath.Create();
-        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, TwoItemValues());
+        Dictionary<string, object?> data = new()
+        {
+            ["title"] = "FooCompany",
+            ["items"] = new[]
+            {
+                new { Name = "A", Qty = 1 },
+                new { Name = "B", Qty = 2 },
+            }
+        };
+        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, data);
 
         using var zip = ZipFile.OpenRead(path.ToString());
 
         // the formula cell: <c r="D8"> (two items shift row 7 to 8) with a namespaced <f> child and no inlineStr type
         var doc = new XmlDocument();
         using (var sheet = zip.GetEntry("xl/worksheets/sheet1.xml")!.Open())
+        {
             doc.Load(sheet);
+        }
+
         var ns = new XmlNamespaceManager(doc.NameTable);
         ns.AddNamespace("x", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
         var formulaCell = doc.SelectSingleNode("//x:c[@r='D8']", ns) as XmlElement;
@@ -90,14 +111,4 @@ public class MiniExcelTemplateCalcChainTests
         Assert.Contains(@"r=""D8""", chain);
         Assert.DoesNotContain(@"r=""B8""", chain);
     }
-
-    private static Dictionary<string, object> TwoItemValues() => new()
-    {
-        ["title"] = "FooCompany",
-        ["items"] = new[]
-        {
-            new { Name = "A", Qty = 1 },
-            new { Name = "B", Qty = 2 },
-        },
-    };
 }

--- a/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateCalcChainTests.cs
+++ b/tests/MiniExcelTests/SaveByTemplate/MiniExcelTemplateCalcChainTests.cs
@@ -1,0 +1,103 @@
+using System.IO.Compression;
+using System.Xml;
+using ClosedXML.Excel;
+using MiniExcelLibs.Tests.Utils;
+using Xunit;
+
+namespace MiniExcelLibs.Tests.SaveByTemplate;
+
+/// <summary>
+/// Regression tests for calcChain.xml handling and '$='-formula cell serialization in template
+/// rendering. A template containing any formula carries a calcChain part whose entries point at
+/// cell addresses; row insertion shifts formula cells, so the chain must be regenerated from the
+/// rendered output — never left stale, and never written empty (a calcChain with zero &lt;c&gt;
+/// entries is schema-invalid and Excel refuses to open the whole file).
+/// </summary>
+public class MiniExcelTemplateCalcChainTests
+{
+    [Fact]
+    public void TemplateWithStaticFormula_DoesNotWriteStaleOrEmptyCalcChain()
+    {
+        // A template with a static Excel formula (below an IEnumerable row) carries a calcChain
+        // pointing at the formula's pre-render address. After rows are inserted the address is
+        // stale — the rendered package must not contain a stale or empty calcChain.
+        using var template = AutoDeletingPath.Create();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            ws.Cell("A1").Value = "{{title}}";
+            ws.Cell("A3").Value = "{{items.Name}}";
+            ws.Cell("B3").Value = "{{items.Qty}}";
+            ws.Cell("B5").FormulaA1 = "SUM(B3:B4)";
+            wb.SaveAs(template.FilePath);
+        }
+
+        using var path = AutoDeletingPath.Create();
+        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, TwoItemValues());
+
+        using var zip = ZipFile.OpenRead(path.ToString());
+        var calcChain = zip.GetEntry("xl/calcChain.xml");
+        if (calcChain != null)
+        {
+            using var reader = new StreamReader(calcChain.Open());
+            var content = reader.ReadToEnd();
+            Assert.Contains("<c ", content);       // an empty calcChain is schema-invalid
+            Assert.DoesNotContain(@"r=""B5""", content); // the pre-render address is stale after the row shift
+        }
+    }
+
+    [Fact]
+    public void DollarFormulaInSparseRow_WritesValidFormulaCellAndCorrectCalcChainRef()
+    {
+        // The '$=' formula sits in column D of a row whose only other cell is in column A, so the
+        // formula cell's child-list position (1) differs from its column (D) — the calcChain ref
+        // must come from the cell's own address. The rendered cell must be a real formula element
+        // in the spreadsheetml namespace, not an inline string.
+        using var template = AutoDeletingPath.Create();
+        using (var wb = new XLWorkbook())
+        {
+            var ws = wb.AddWorksheet("Sheet1");
+            // the static formula makes the authoring library emit a calcChain part, so the
+            // regeneration path runs; without one the template carries no chain to regenerate
+            ws.Cell("F1").FormulaA1 = "1+1";
+            ws.Cell("A5").Value = "{{items.Name}}";
+            ws.Cell("B5").Value = "{{items.Qty}}";
+            ws.Cell("A7").Value = "Total";
+            ws.Cell("D7").Value = "$=SUM(B{{$enumrowstart}}:B{{$enumrowend}})";
+            wb.SaveAs(template.FilePath);
+        }
+
+        using var path = AutoDeletingPath.Create();
+        MiniExcel.SaveAsByTemplate(path.ToString(), template.FilePath, TwoItemValues());
+
+        using var zip = ZipFile.OpenRead(path.ToString());
+
+        // the formula cell: <c r="D8"> (two items shift row 7 to 8) with a namespaced <f> child and no inlineStr type
+        var doc = new XmlDocument();
+        using (var sheet = zip.GetEntry("xl/worksheets/sheet1.xml")!.Open())
+            doc.Load(sheet);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("x", "http://schemas.openxmlformats.org/spreadsheetml/2006/main");
+        var formulaCell = doc.SelectSingleNode("//x:c[@r='D8']", ns) as XmlElement;
+        Assert.NotNull(formulaCell);
+        Assert.Equal("SUM(B5:B6)", formulaCell.SelectSingleNode("x:f", ns)?.InnerText);
+        Assert.NotEqual("inlineStr", formulaCell.GetAttribute("t"));
+
+        // and the regenerated calcChain points at the formula's real address, not the one derived
+        // from the cell's position in the row (which would be column B here)
+        using var chainReader = new StreamReader(zip.GetEntry("xl/calcChain.xml")!.Open());
+        var chain = chainReader.ReadToEnd();
+        Assert.Contains(@"r=""D8""", chain);
+        Assert.DoesNotContain(@"r=""B8""", chain);
+    }
+
+    private static Dictionary<string, object> TwoItemValues() => new()
+    {
+        ["title"] = "FooCompany",
+        ["items"] = new[]
+        {
+            new { Name = "A", Qty = 1 },
+            new { Name = "B", Qty = 2 },
+        },
+    };
+}


### PR DESCRIPTION

## Problem

Rendering a template that contains **any formula** produces a file that Excel refuses to open ("the file is corrupt and cannot be opened" — repair also fails). Two independent defects in `SaveAsByTemplate`, isolated against Excel (Microsoft 365):

### 1. Broken `calcChain.xml` after rendering

A template containing formulas carries `xl/calcChain.xml`, whose `<c>` entries point at formula-cell addresses. Rendering an `IEnumerable` inserts rows and shifts those cells, so the chain is regenerated (#491) — but the regeneration is broken in three ways:

- **Wrong cell references.** `ProcessFormulas` derives the calcChain ref from the cell's *position in the row's child list* (`ConvertXyToCell(ci + 1, rowIndex)`). In a sparse row (e.g. a label in column A and a `$=` formula in column F, no cells between), the formula is child #2 and gets recorded as column **B**. Excel rejects a chain pointing at non-formula cells.
- **Schema-invalid empty chain.** Only `$=` cells are collected. When a template's formulas are all static Excel formulas (a footer `VLOOKUP`, a `=E27*B27` row total, …), the regenerated chain has **zero entries** — and a `calcChain` with no `<c>` children is schema-invalid (ECMA-376), so Excel rejects the whole package.
- **Stale refs accumulate.** `_calcChainCellRefs` is never cleared between sheets, so a multi-sheet template duplicates sheet 1's refs into sheet 2's entries; and one code path copied the template's *original* calcChain into the output verbatim, whose refs are stale the moment rows shift.

### 2. `$=` formulas serialize as invalid cells

`ProcessFormulas` creates the `f` element without a namespace prefix; it then relies on a default `xmlns` declaration that `CleanXml` strips, leaving `<f>` in **no namespace**. The cell also keeps its `t="inlineStr"` attribute while no longer containing an `<is>` child:

```xml
<x:c r="F14" s="0" t="inlineStr"><f>SUM(G11:G13)</f></x:c>   <!-- rejected by Excel -->
```

Either defect alone is enough for Excel to refuse the file, so in 1.45.0 **the template-formula feature and any formula-bearing template are unusable**. Likely the root cause behind reports like #632/#857; reproduced identically on `2.0.0-preview.4`.

## Fix

`ExcelOpenXmlTemplate.Impl.cs` — `ProcessFormulas`:
- create the `f` element with the document's prefix so it survives `CleanXml` (`<x:f>…</x:f>`);
- remove the cell's `t` attribute (the cell no longer holds an inline string);
- take the calcChain ref's column from the cell's own `r` attribute instead of its child-list position (falls back to the old computation when `r` is absent).

`ExcelOpenXmlTemplate.cs` — `SaveAsByTemplate`:
- clear `_calcChainCellRefs` after each sheet;
- write the regenerated calcChain **only when it has entries**; otherwise drop the part entirely — the calculation chain is a rebuildable cache that Excel regenerates on open, while an empty or stale one makes the file unopenable;
- remove the branch that copied the template's original (stale) calcChain into the output.

## Validation

- New regression tests (`MiniExcelTemplateCalcChainTests`) fail on current `1.45.0` sources and pass with the fix. Templates are authored in-test with ClosedXML (already a test dependency).
- Full `MiniExcelTests` suite: 360/360 pass.
- Manually verified with Excel (COM automation) on a matrix of templates — plain, number formats, merged cells, hidden rows + defined names, static `VLOOKUP`, `$=SUM`, and a real-world quote template (embedded images, custom XML parts, conditional formatting, dozens of static formulas). All rendered files that previously failed now open, and the formulas compute (`$=SUM` ranges resolve to the expanded rows, per-row static formulas recalculate).

## Notes

- When the chain is dropped, the workbook relationship and `[Content_Types]` override still reference the absent part. Excel tolerates this; strict consumers (System.IO.Packaging) do not. Cleaning those two entries requires touching the entry-copy path — happy to add it to this PR if you prefer.
- Unrelated pre-existing quirk (not addressed here): defined names whose range lies *below* the inserted rows are not shifted, so formulas referencing them can mis-resolve after rendering.
- The same two defects reproduce on the `2.0.0-preview` line; I can port this fix there if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formula cells generated from templates so they retain valid references and Excel-compatible formatting, including sparse-row scenarios.
  * Improved calculation-chain handling to prevent stale or empty formula references in generated workbooks.
  * Removed obsolete calculation-chain metadata when no valid formula entries are produced.

* **Documentation**
  * Reformatted project badges in the NuGet README for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->